### PR TITLE
Use new releaser action

### DIFF
--- a/.github/worflows/releaser.yml
+++ b/.github/worflows/releaser.yml
@@ -1,0 +1,20 @@
+name: Releaser
+on:
+  pull_request:
+    types: [ labeled, closed ]
+  issue_comment:
+    types: [ created, edited ]
+
+jobs:
+  pr_merged:
+    runs-on: ubuntu-latest
+    name: Trigger job on comment, merge or label
+    steps:
+      - name: Trigger release
+        id: release
+        uses: RedHatInsights/frontend-releaser@v1
+        with:
+          bot-name: nacho-bot
+          gh-bot-token: ${{ secrets.GH_BOT_TOKEN }}
+          travis-config: '{"token":"${{ secrets.TRAVIS_TOKEN }}"}'
+          allowed-users: '["karelhala", "ryelo", "Hyperkid123", "fhlavac"]'


### PR DESCRIPTION
### Description

Since heroku no longer supports free tier we should move away from our old bot to the new action we've created https://github.com/RedHatInsights/frontend-releaser. All secret tokens has been added.