### PR TITLE
docs: update usage in README for new-gen clients

### DIFF
--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -18,12 +18,12 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { IntegrationsApi } from '@redhat-cloud-services/integrations-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/integrations-client/utils'; 
+import createEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1CreateEndpoint';
+import enableEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1EnableEndpoint';
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = new IntegrationsApi(undefined, BASE_PATH, instance);
+const integrationsApi = APIFactory(BASE_PATH, undefined, { createEndpoint, enableEndpoint });
 export integrationsApi;
 ```
 
@@ -50,17 +50,17 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = new IntegrationsApi(undefined, BASE_PATH, instance);
+const integrationsApi = APIFactory(BASE_PATH, instance, { createEndpoint, enableEndpoint });
 export integrationsApi;
 ```
 
 ## Building
 
-Run `nx build integrations-client` to build the library.
+Run `nx build @redhat-cloud-services/integrations-client` to build the library.
 
 ## Running unit tests
 
-Run `nx test integrations-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test @redhat-cloud-services/integrations-client` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/integrations/doc/README.md
+++ b/packages/integrations/doc/README.md
@@ -1,5 +1,3 @@
-@redhat-cloud-services/integrations-client / [Exports](modules.md)
-
 # Javascript client for Integrations API
 If you want to use [RedHatInsights/notifications-backend](https://github.com/RedHatInsights/notifications-backend) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
@@ -20,12 +18,12 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { IntegrationsApi } from '@redhat-cloud-services/integrations-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/integrations-client/utils'; 
+import createEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1CreateEndpoint';
+import enableEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1EnableEndpoint';
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = new IntegrationsApi(undefined, BASE_PATH, instance);
+const integrationsApi = APIFactory(BASE_PATH, undefined, { createEndpoint, enableEndpoint });
 export integrationsApi;
 ```
 
@@ -52,17 +50,17 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = new IntegrationsApi(undefined, BASE_PATH, instance);
+const integrationsApi = APIFactory(BASE_PATH, instance, { createEndpoint, enableEndpoint });
 export integrationsApi;
 ```
 
 ## Building
 
-Run `nx build integrations-client` to build the library.
+Run `nx build @redhat-cloud-services/integrations-client` to build the library.
 
 ## Running unit tests
 
-Run `nx test integrations-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test @redhat-cloud-services/integrations-client` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -18,12 +18,14 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { NotificationsApi } from '@redhat-cloud-services/notifications-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/notifications-client/utils'; 
+import createBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1CreateBehaviorGroup';
+import updateBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1UpdateBehaviorGroup';
+import deleteBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1DeleteBehaviorGroup';
+
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = new NotificationsApi(undefined, BASE_PATH, instance);
+const notificationsApi = APIFactory(BASE_PATH, undefined, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
 export notificationsApi;
 ```
 
@@ -50,17 +52,17 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = new NotificationsApi(undefined, BASE_PATH, instance);
+const notificationsApi = APIFactory(BASE_PATH, instance, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
 export notificationsApi;
 ```
 
 ## Building
 
-Run `nx build notifications-client` to build the library.
+Run `nx build @redhat-cloud-services/notifications-client` to build the library.
 
 ## Running unit tests
 
-Run `nx test notifications-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test @redhat-cloud-services/notifications-client` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/notifications/doc/README.md
+++ b/packages/notifications/doc/README.md
@@ -1,5 +1,3 @@
-@redhat-cloud-services/notifications-client / [Exports](modules.md)
-
 # Javascript client for Notifications API
 If you want to use [RedHatInsights/notifications-backend](https://github.com/RedHatInsights/notifications-backend) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
@@ -20,12 +18,14 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { NotificationsApi } from '@redhat-cloud-services/notifications-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/notifications-client/utils'; 
+import createBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1CreateBehaviorGroup';
+import updateBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1UpdateBehaviorGroup';
+import deleteBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1DeleteBehaviorGroup';
+
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = new NotificationsApi(undefined, BASE_PATH, instance);
+const notificationsApi = APIFactory(BASE_PATH, undefined, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
 export notificationsApi;
 ```
 
@@ -52,17 +52,17 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = new NotificationsApi(undefined, BASE_PATH, instance);
+const notificationsApi = APIFactory(BASE_PATH, instance, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
 export notificationsApi;
 ```
 
 ## Building
 
-Run `nx build notifications-client` to build the library.
+Run `nx build @redhat-cloud-services/notifications-client` to build the library.
 
 ## Running unit tests
 
-Run `nx test notifications-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test @redhat-cloud-services/notifications-client` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 


### PR DESCRIPTION
For [RHCLOUD-28020](https://issues.redhat.com/browse/RHCLOUD-28020). Currently only updating the new generator clients (integrations and notifications) as the usage change only applies to them. As more clients get converted, their READMEs can be updated to match these.