### PR TITLE
Change executor to match previous dist output

### DIFF
--- a/packages/build-utils/src/executors/builder/executor.ts
+++ b/packages/build-utils/src/executors/builder/executor.ts
@@ -29,6 +29,10 @@ async function runTSC(tsConfigPath: string, outputDir: string) {
   }
 }
 
+async function copyClient(clientDir: string, outputDir: string) {
+  return asyncExec(`rsync -avz --exclude dist ${clientDir}/* ${outputDir}`);
+}
+
 async function copyAssets(assets: string[], outputDir: string) {
   return Promise.all(assets.map((asset) => asyncExec(`cp -r ${asset} ${outputDir}`)));
 }
@@ -53,7 +57,11 @@ export default async function runExecutor(options: BuilderExecutorSchemaType, co
     validateExistingFile(options.cjsTsConfig),
     validateExistingFile(projectPackageJsonPath),
   ]);
-  await Promise.all([runTSC(options.esmTsConfig, `${outputDir}/esm`), runTSC(options.cjsTsConfig, outputDir)]);
+  await Promise.all([
+    runTSC(options.esmTsConfig, `${outputDir}/esm`),
+    runTSC(options.cjsTsConfig, `${outputDir}/dist`),
+    copyClient(currentProjectRoot, outputDir),
+  ]);
   await copyAssets(assets, outputDir);
   return {
     success: true,


### PR DESCRIPTION
For [RHCLOUD-31842](https://issues.redhat.com/browse/RHCLOUD-31842). @Hyperkid123 I _think_ this should get us back to where we were. I'm able to match the output of https://www.npmjs.com/package/@redhat-cloud-services/rbac-client/v/1.2.13?activeTab=code if I delete the current `dist/` in a client, make a change to the `README`, and then build. Worst case it also appends the contents of the previous `dist` into the main new `dist`. Next step for this is to make `README` changes to all the clients with this new executor to revert to the previous output in a minor bump. Then, I'll open a tech debt story to revert all these changes in a major bump for all clients, forcing the normal `dist` output we have currently here https://www.npmjs.com/package/@redhat-cloud-services/rbac-client?activeTab=code