### PR TITLE
Add new exec for old output

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -32,9 +32,6 @@ runs:
     - name: Build
       shell: bash
       run: npx nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client
-    - name: Copy Metadata
-      shell: bash
-      run: npx nx run-many -t copyMetadata --exclude=@redhat-cloud-services/CLIENTNAME-client
     - name: Set publish config
       env:
         NPM_TOKEN: ${{ inputs.npm_token }}
@@ -45,7 +42,7 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
         GITHUB_TOKEN: ${{ inputs.gh_token }}
-      run: npx nx affected --base=last-release --parallel=1 --target=version --postTargets=copyMetadata,npm,github --trackDeps --exclude=@redhat-cloud-services/CLIENTNAME-client
+      run: npx nx affected --base=last-release --parallel=1 --target=version --postTargets=npm,github --trackDeps --exclude=@redhat-cloud-services/CLIENTNAME-client
     - name: Tag last-release
       shell: bash
       run: |

--- a/nx.json
+++ b/nx.json
@@ -9,11 +9,6 @@
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
     },
-    "copyMetadata": {
-      "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
-    },
     "lint": {
       "cache": true,
       "inputs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nx/devkit": "17.1.3",
         "@openshift/dynamic-plugin-sdk-webpack": "^3.0.0",
         "eslint-plugin-prettier": "^5.0.1",
+        "fs-extra": "^11.2.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -5331,21 +5332,6 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
-    "node_modules/@lerna/version/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@lerna/version/node_modules/glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -6070,20 +6056,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@nrwl/cli/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@nrwl/cli/node_modules/glob": {
@@ -6860,20 +6832,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@nx/js/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/@nx/js/node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -7177,20 +7135,6 @@
       },
       "peerDependencies": {
         "typescript": "^3 || ^4 || ^5"
-      }
-    },
-    "node_modules/@nx/plugin/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@nx/react": {
@@ -7533,20 +7477,6 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "node_modules/@nx/workspace/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@nx/workspace/node_modules/glob": {
@@ -8087,6 +8017,20 @@
         "url": "https://opencollective.com/openapi_generator"
       }
     },
+    "node_modules/@openapitools/openapi-generator-cli/node_modules/fs-extra": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@openapitools/openapi-generator-cli/node_modules/tslib": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -8341,20 +8285,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=18.0.0"
-      }
-    },
-    "node_modules/@semantic-release/changelog/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
@@ -9005,21 +8935,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@semantic-release/npm/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/get-stream": {
@@ -10431,6 +10346,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -10522,6 +10447,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/lodash": {
       "version": "4.14.202",
@@ -18033,6 +17967,20 @@
         }
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -18141,17 +18089,16 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
@@ -21419,20 +21366,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/lerna/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/lerna/node_modules/glob": {
@@ -26938,19 +26871,6 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "node_modules/nx/node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/nx/node_modules/glob": {
@@ -34200,9 +34120,12 @@
       "version": "0.0.1",
       "dependencies": {
         "@nx/devkit": "17.1.3",
+        "fs-extra": "^11.2.0",
         "semver": "^7.5.4",
-        "tslib": "^2.0.0",
         "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "^11.0.4"
       }
     },
     "packages/catalog": {
@@ -34217,7 +34140,7 @@
     },
     "packages/config-manager": {
       "name": "@redhat-cloud-services/config-manager-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34238,7 +34161,7 @@
     },
     "packages/entitlements": {
       "name": "@redhat-cloud-services/entitlements-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34259,7 +34182,7 @@
     },
     "packages/host-inventory": {
       "name": "@redhat-cloud-services/host-inventory-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34268,7 +34191,7 @@
     },
     "packages/insights": {
       "name": "@redhat-cloud-services/insights-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34277,7 +34200,7 @@
     },
     "packages/integrations": {
       "name": "@redhat-cloud-services/integrations-client",
-      "version": "2.2.3",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34286,7 +34209,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/notifications-client",
-      "version": "2.2.3",
+      "version": "2.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34295,7 +34218,7 @@
     },
     "packages/patch": {
       "name": "@redhat-cloud-services/patch-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34304,7 +34227,7 @@
     },
     "packages/policies": {
       "name": "@redhat-cloud-services/policies-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34313,7 +34236,7 @@
     },
     "packages/quickstarts": {
       "name": "@redhat-cloud-services/quickstarts-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34322,7 +34245,7 @@
     },
     "packages/rbac": {
       "name": "@redhat-cloud-services/rbac-client",
-      "version": "1.3.2",
+      "version": "1.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34331,7 +34254,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/remediations-client",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34340,7 +34263,7 @@
     },
     "packages/sources": {
       "name": "@redhat-cloud-services/sources-client",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34349,7 +34272,7 @@
     },
     "packages/topological-inventory": {
       "name": "@redhat-cloud-services/topological-inventory-client",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -34358,7 +34281,7 @@
     },
     "packages/vulnerabilities": {
       "name": "@redhat-cloud-services/vulnerabilities-client",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -38297,18 +38220,6 @@
           "dev": true,
           "peer": true
         },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "glob": {
           "version": "7.1.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -38852,17 +38763,6 @@
             "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
             "micromatch": "^4.0.4"
-          }
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         },
         "glob": {
@@ -39432,17 +39332,6 @@
             "micromatch": "^4.0.4"
           }
         },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -39624,17 +39513,6 @@
           "dev": true,
           "requires": {
             "esquery": "^1.4.0"
-          }
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         }
       }
@@ -39876,17 +39754,6 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
           "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
           "dev": true
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         },
         "glob": {
           "version": "7.1.4",
@@ -40363,6 +40230,17 @@
         "tslib": "2.0.3"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "tslib": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
@@ -40490,8 +40368,9 @@
       "version": "file:packages/build-utils",
       "requires": {
         "@nx/devkit": "17.1.3",
+        "@types/fs-extra": "^11.0.4",
+        "fs-extra": "^11.2.0",
         "semver": "^7.5.4",
-        "tslib": "^2.0.0",
         "zod": "^3.22.4"
       }
     },
@@ -40605,19 +40484,6 @@
         "aggregate-error": "^3.0.0",
         "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -41077,18 +40943,6 @@
             "onetime": "^6.0.0",
             "signal-exit": "^4.1.0",
             "strip-final-newline": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
@@ -42014,6 +41868,16 @@
         "@types/send": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "requires": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -42104,6 +41968,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.202",
@@ -47624,6 +47497,17 @@
         "tapable": "^2.2.1"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
         "schema-utils": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -47713,10 +47597,9 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
-      "dev": true,
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -50183,17 +50066,6 @@
             "glob-parent": "^5.1.2",
             "merge2": "^1.3.0",
             "micromatch": "^4.0.4"
-          }
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
           }
         },
         "glob": {
@@ -54179,16 +54051,6 @@
           "version": "16.3.1",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
           "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
-        },
-        "fs-extra": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
         },
         "glob": {
           "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test:unit:affected": "nx affected -t test --exclude=@redhat-cloud-services/CLIENTNAME-client",
     "test": "npm-run-all --parallel test:* --exclude=@redhat-cloud-services/CLIENTNAME-client",
     "build": "nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client",
-    "copyMetadata": "nx run-many -t copyMetadata --exclude=@redhat-cloud-services/CLIENTNAME-client",
     "lint": "nx run-many -t lint --exclude=@redhat-cloud-services/CLIENTNAME-client",
     "lint:fix": "nx run-many -t lint --fix --exclude=@redhat-cloud-services/CLIENTNAME-client",
     "version": "nx run-many -t version --exclude=@redhat-cloud-services/CLIENTNAME-client"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@nx/devkit": "17.1.3",
     "@openshift/dynamic-plugin-sdk-webpack": "^3.0.0",
     "eslint-plugin-prettier": "^5.0.1",
+    "fs-extra": "^11.2.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/build-utils/executors.json
+++ b/packages/build-utils/executors.json
@@ -4,6 +4,11 @@
       "implementation": "./src/executors/builder/executor",
       "schema": "./src/executors/builder/schema.json",
       "description": "builder executor"
+    },
+    "old-builder": {
+      "implementation": "./src/executors/old-builder/old-executor",
+      "schema": "./src/executors/old-builder/schema.json",
+      "description": "old-builder executor"
     }
   }
 }

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "dependencies": {
     "@nx/devkit": "17.1.3",
+    "fs-extra": "^11.2.0",
     "semver": "^7.5.4",
-    "tslib": "^2.0.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "tslib": "^2.3.0"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/packages/build-utils/src/executors/old-builder/old-executor.spec.ts
+++ b/packages/build-utils/src/executors/old-builder/old-executor.spec.ts
@@ -1,0 +1,35 @@
+import { OldBuilderExecutorSchema } from './schema';
+import executor from './old-executor';
+import { ExecutorContext } from '@nx/devkit';
+
+jest.mock('fs', () => ({
+  __esModule: true,
+  stat: (_path, cb) => cb(),
+  mkdir: (_path, _options, cb) => cb(),
+  copyFile: (_src, _dest, cb) => cb(),
+  unlink: (_path, cb) => cb(),
+}));
+
+jest.mock('fs-extra', () => ({
+  __esModule: true,
+  copy: (_src, _dest, cb) => cb(),
+}));
+
+jest.mock('child_process', () => ({
+  __esModule: true,
+  exec: (_command, cb) => cb(),
+  execSync: () => undefined,
+}));
+
+const options: OldBuilderExecutorSchema = {
+  main: 'main',
+  tsConfig: 'tsConfig',
+  outputPath: 'outputPath',
+};
+
+describe('Builder Executor', () => {
+  it('can run', async () => {
+    const output = await executor(options, {} as ExecutorContext);
+    expect(output.success).toBe(true);
+  });
+});

--- a/packages/build-utils/src/executors/old-builder/old-executor.ts
+++ b/packages/build-utils/src/executors/old-builder/old-executor.ts
@@ -1,0 +1,88 @@
+import { ExecutorContext } from '@nx/devkit';
+import { z } from 'zod';
+import { stat, mkdir, copyFile, unlink } from 'fs';
+import { copy } from 'fs-extra';
+import { promisify } from 'util';
+import { execSync } from 'child_process';
+
+const asyncStat = promisify(stat);
+const asyncMkdir = promisify(mkdir);
+const asyncCopyfile = promisify(copyFile);
+const asyncCopyfolder = promisify(copy);
+const asyncRemove = promisify(unlink);
+
+const OldBuilderExecutorSchema = z.object({
+  tsConfig: z.string(),
+  outputPath: z.string(),
+  main: z.string(),
+});
+
+export type OldBuilderExecutorSchemaType = z.infer<typeof OldBuilderExecutorSchema>;
+
+async function validateExistingFile(path: string) {
+  return asyncStat(path);
+}
+
+async function runTSC(tsConfigPath: string, outputDir: string) {
+  try {
+    execSync(`tsc -p ${tsConfigPath} --outDir ${outputDir}`, { stdio: 'inherit' });
+  } catch (error) {
+    console.log(error);
+    throw new Error(`Failed to run tsc for ${tsConfigPath}`);
+  }
+}
+
+async function makeDirs(pathList: string[]) {
+  return Promise.all(pathList.map((path) => asyncMkdir(path, { recursive: true })));
+}
+
+async function copyFiles(srcDir: string, destDir: string, files: string[]) {
+  return Promise.all(
+    files.map((file) => {
+      stat(`${srcDir}/${file}`, (error, stats) => {
+        if (stats) {
+          return asyncCopyfile(`${srcDir}/${file}`, `${destDir}/${file}`);
+        }
+      });
+    }),
+  );
+}
+
+async function copyFolder(folderPath: string, dest: string) {
+  return asyncCopyfolder(folderPath, dest);
+}
+
+async function removePackage(distPath: string) {
+  return asyncRemove(`${distPath}/package.json`).catch(console.error);
+}
+
+export default async function runExecutor(options: OldBuilderExecutorSchemaType, context: ExecutorContext) {
+  try {
+    OldBuilderExecutorSchema.parse(options);
+  } catch (error) {
+    throw new Error(`Invalid options passed to builder executor: ${error}`);
+  }
+
+  const projectName = context.projectName;
+  const projectRoot = context.root;
+  const currentProjectRoot = context.projectsConfigurations?.projects?.[projectName]?.root;
+  const packageName = currentProjectRoot?.split('/')[1];
+  const outputDir = `${projectRoot}/${options.outputPath}`;
+  const pathList = [`dist/${packageName}/dist`, `dist/${packageName}/doc`];
+  const filesList = [`README.md`, `package.json`, `CHANGELOG.md`, `LICENSE`];
+  const filesDest = `dist/${packageName}`;
+  const distSrc = `packages/${packageName}/dist`;
+  const distDest = `dist/${packageName}/dist`;
+  const docsSrc = `packages/${packageName}/doc`;
+  const docsDest = `dist/${packageName}/doc`;
+
+  await validateExistingFile(options.tsConfig);
+  await runTSC(options.tsConfig, outputDir);
+  await makeDirs(pathList);
+  await copyFiles(currentProjectRoot, filesDest, filesList);
+  await Promise.all([copyFolder(distSrc, distDest), copyFolder(docsSrc, docsDest)]);
+  await removePackage(distDest);
+  return {
+    success: true,
+  };
+}

--- a/packages/build-utils/src/executors/old-builder/schema.d.ts
+++ b/packages/build-utils/src/executors/old-builder/schema.d.ts
@@ -1,0 +1,3 @@
+import { OldBuilderExecutorSchemaType } from './old-executor';
+
+export type OldBuilderExecutorSchema = OldBuilderExecutorSchemaType;

--- a/packages/build-utils/src/executors/old-builder/schema.json
+++ b/packages/build-utils/src/executors/old-builder/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "version": 2,
+  "title": "Builder executor",
+  "description": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/packages/config-manager/project.json
+++ b/packages/config-manager/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/config-manager/dist",
         "main": "packages/config-manager/index.ts",

--- a/packages/config-manager/project.json
+++ b/packages/config-manager/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/config-manager/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/config-manager/dist dist/config-manager/doc",
-            "cp packages/config-manager/README.md packages/config-manager/package.json packages/config-manager/LICENSE packages/config-manager/CHANGELOG.md dist/config-manager",
-            "cp packages/config-manager/dist/* dist/config-manager/dist",
-            "cp -r packages/config-manager/doc/* dist/config-manager/doc",
-            "rm -f dist/config-manager/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/config-manager-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/entitlements/project.json
+++ b/packages/entitlements/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/entitlements/dist",
         "main": "packages/entitlements/index.ts",

--- a/packages/entitlements/project.json
+++ b/packages/entitlements/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/entitlements/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/entitlements/dist dist/entitlements/doc",
-            "cp packages/entitlements/README.md packages/entitlements/package.json packages/entitlements/LICENSE packages/entitlements/CHANGELOG.md dist/entitlements",
-            "cp packages/entitlements/dist/* dist/entitlements/dist",
-            "cp -r packages/entitlements/doc/* dist/entitlements/doc",
-            "rm -f dist/entitlements/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/entitlements-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/host-inventory/project.json
+++ b/packages/host-inventory/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/host-inventory/dist",
         "main": "packages/host-inventory/index.ts",

--- a/packages/host-inventory/project.json
+++ b/packages/host-inventory/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/host-inventory/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/host-inventory/dist dist/host-inventory/doc",
-            "cp packages/host-inventory/README.md packages/host-inventory/package.json packages/host-inventory/LICENSE packages/host-inventory/CHANGELOG.md dist/host-inventory",
-            "cp packages/host-inventory/dist/* dist/host-inventory/dist",
-            "cp -r packages/host-inventory/doc/* dist/host-inventory/doc",
-            "rm -f dist/host-inventory/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/host-inventory-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/insights/project.json
+++ b/packages/insights/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/insights/dist",
         "main": "packages/insights/index.ts",

--- a/packages/insights/project.json
+++ b/packages/insights/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/insights/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/insights/dist dist/insights/doc",
-            "cp packages/insights/README.md packages/insights/package.json packages/insights/LICENSE packages/insights/CHANGELOG.md dist/insights",
-            "cp packages/insights/dist/* dist/insights/dist",
-            "cp -r packages/insights/doc/* dist/insights/doc",
-            "rm -f dist/insights/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/insights-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/integrations/project.json
+++ b/packages/integrations/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/integrations/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/integrations/dist dist/integrations/doc",
-            "cp packages/integrations/README.md packages/integrations/package.json packages/integrations/LICENSE packages/integrations/CHANGELOG.md dist/integrations",
-            "cp -r packages/integrations/dist/* dist/integrations/dist",
-            "cp -r packages/integrations/doc/* dist/integrations/doc",
-            "rm -f dist/integrations/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/integrations-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/integrations/project.json
+++ b/packages/integrations/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/integrations/dist",
         "main": "packages/integrations/index.ts",

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/notifications/dist",
         "main": "packages/notifications/index.ts",

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -12,20 +12,6 @@
         "tsConfig": "packages/notifications/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/notifications/dist dist/notifications/doc",
-            "cp packages/notifications/README.md packages/notifications/package.json packages/notifications/LICENSE packages/notifications/CHANGELOG.md dist/notifications",
-            "cp -r packages/notifications/dist/* dist/notifications/dist",
-            "cp -r packages/notifications/doc/* dist/notifications/doc",
-            "rm -f dist/notifications/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },
     "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/notifications-client {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/patch/project.json
+++ b/packages/patch/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/patch/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/patch/dist dist/patch/doc",
-            "cp packages/patch/README.md packages/patch/package.json packages/patch/CHANGELOG.md dist/patch",
-            "cp packages/patch/dist/* dist/patch/dist",
-            "cp -r packages/patch/doc/* dist/patch/doc",
-            "rm -f dist/patch/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/patch-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/patch/project.json
+++ b/packages/patch/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/patch/dist",
         "main": "packages/patch/index.ts",

--- a/packages/policies/project.json
+++ b/packages/policies/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/policies/dist",
         "main": "packages/policies/index.ts",

--- a/packages/policies/project.json
+++ b/packages/policies/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/policies/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/policies/dist dist/policies/doc",
-            "cp packages/policies/README.md packages/policies/package.json packages/policies/CHANGELOG.md dist/policies",
-            "cp packages/policies/dist/* dist/policies/dist",
-            "cp -r packages/policies/doc/* dist/policies/doc",
-            "rm -f dist/policies/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/policies-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/quickstarts/project.json
+++ b/packages/quickstarts/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/quickstarts/dist",
         "main": "packages/quickstarts/index.ts",

--- a/packages/quickstarts/project.json
+++ b/packages/quickstarts/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/quickstarts/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/quickstarts/dist dist/quickstarts/doc",
-            "cp packages/quickstarts/README.md packages/quickstarts/package.json packages/quickstarts/CHANGELOG.md dist/quickstarts",
-            "cp packages/quickstarts/dist/* dist/quickstarts/dist",
-            "cp -r packages/quickstarts/doc/* dist/quickstarts/doc",
-            "rm -f dist/quickstarts/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/quickstarts-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/rbac/project.json
+++ b/packages/rbac/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/rbac/dist",
         "main": "packages/rbac/index.ts",

--- a/packages/rbac/project.json
+++ b/packages/rbac/project.json
@@ -12,20 +12,6 @@
         "tsConfig": "packages/rbac/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/rbac/dist dist/rbac/doc",
-            "cp packages/rbac/README.md packages/rbac/package.json packages/rbac/LICENSE packages/rbac/CHANGELOG.md dist/rbac",
-            "cp packages/rbac/dist/* dist/rbac/dist",
-            "cp -r packages/rbac/doc/* dist/rbac/doc",
-            "rm -f dist/rbac/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },
     "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/rbac-client {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/remediations/project.json
+++ b/packages/remediations/project.json
@@ -12,20 +12,6 @@
         "tsConfig": "packages/remediations/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/remediations/dist dist/remediations/doc",
-            "cp packages/remediations/README.md packages/remediations/package.json packages/remediations/CHANGELOG.md dist/remediations",
-            "cp packages/remediations/dist/* dist/remediations/dist",
-            "cp -r packages/remediations/doc/* dist/remediations/doc",
-            "rm -f dist/remediations/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },
     "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/remediations-client {args.ver} {args.tag}",
       "dependsOn": ["build"]

--- a/packages/remediations/project.json
+++ b/packages/remediations/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/remediations/dist",
         "main": "packages/remediations/index.ts",

--- a/packages/sources/project.json
+++ b/packages/sources/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/sources/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/sources/dist dist/sources/doc",
-            "cp packages/sources/README.md packages/sources/package.json packages/sources/LICENSE packages/sources/CHANGELOG.md dist/sources",
-            "cp packages/sources/dist/* dist/sources/dist",
-            "cp -r packages/sources/doc/* dist/sources/doc",
-            "rm -f dist/sources/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/sources-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/sources/project.json
+++ b/packages/sources/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/sources/dist",
         "main": "packages/sources/index.ts",

--- a/packages/topological-inventory/project.json
+++ b/packages/topological-inventory/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/topological-inventory/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/topological-inventory/dist dist/topological-inventory/doc",
-            "cp packages/topological-inventory/README.md packages/topological-inventory/package.json packages/topological-inventory/LICENSE packages/topological-inventory/CHANGELOG.md dist/topological-inventory",
-            "cp packages/topological-inventory/dist/* dist/topological-inventory/dist",
-            "cp -r packages/topological-inventory/doc/* dist/topological-inventory/doc",
-            "rm -f dist/topological-inventory/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/topological-inventory-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },

--- a/packages/topological-inventory/project.json
+++ b/packages/topological-inventory/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/topological-inventory/dist",
         "main": "packages/topological-inventory/index.ts",

--- a/packages/vulnerabilities/project.json
+++ b/packages/vulnerabilities/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@redhat-cloud-services/build-utils:old-builder",
       "options": {
         "outputPath": "packages/vulnerabilities/dist",
         "main": "packages/vulnerabilities/index.ts",

--- a/packages/vulnerabilities/project.json
+++ b/packages/vulnerabilities/project.json
@@ -12,20 +12,7 @@
         "tsConfig": "packages/vulnerabilities/tsconfig.cjs.json"
       }
     },
-    "copyMetadata": {
-      "executor": "nx:run-commands",
-      "options": {
-          "commands": [
-            "mkdir -p dist/vulnerabilities/dist dist/vulnerabilities/doc",
-            "cp packages/vulnerabilities/README.md packages/vulnerabilities/package.json packages/vulnerabilities/LICENSE packages/vulnerabilities/CHANGELOG.md dist/vulnerabilities",
-            "cp -r packages/vulnerabilities/dist/* dist/vulnerabilities/dist",
-            "cp -r packages/vulnerabilities/doc/* dist/vulnerabilities/doc",
-            "rm -f dist/vulnerabilities/dist/package.json"
-          ],
-          "parallel": false
-      },
-      "dependsOn": ["build"]
-    },    "publish": {
+    "publish": {
       "command": "node tools/scripts/publish.mjs @redhat-cloud-services/vulnerabilities-client {args.ver} {args.tag}",
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
Since [GH actions](https://github.com/RedHatInsights/javascript-clients/actions/runs/8751031768/job/24015881192#step:3:376) doesn't want to use things like `mkdir`, we're writing a custom executor using `fs` and `fs-extra` instead to get our output matching our old clients.