### PR TITLE
Publish javascript-shared-clients package

### DIFF
--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,6 +1,7 @@
 @redhat-cloud-services/javascript-clients-shared / [Exports](modules.md)
 
 # Shared Javascript utils for javascript-clients
+This package contains some common configurations and functions needed for clients using the new [javascript-clients](https://github.com/RedHatInsights/javascript-clients) generator.
 
 ## Install
 NPM

--- a/packages/shared/project.json
+++ b/packages/shared/project.json
@@ -34,7 +34,8 @@
       "executor": "@jscutlery/semver:version",
       "options": {
         "push": true,
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "commitMessageFormat": "release: bump {projectName} to {version} [skip ci]"
       }
     },
     "github": {
@@ -47,7 +48,8 @@
     "npm": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "access": "public"
+        "access": "public",
+        "distFolderPath": "dist/shared"
       }
     },
     "syncDependencies": {


### PR DESCRIPTION
Seems like there were [some issues](https://github.com/RedHatInsights/javascript-clients/actions/runs/8920058635/job/24497448706) publishing the shared package because of an executor error? Need this package published consumption in integrations and notifications clients. If this release fails, I can tweak the executor to fix the above error.