### PR TITLE
fix: add shared package to compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33624,9 +33624,10 @@
     },
     "packages/compliance": {
       "name": "@redhat-cloud-services/compliance-client",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }
@@ -33669,18 +33670,20 @@
     },
     "packages/integrations": {
       "name": "@redhat-cloud-services/integrations-client",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/notifications-client",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }
@@ -33732,7 +33735,7 @@
     },
     "packages/shared": {
       "name": "@redhat-cloud-services/javascript-clients-shared",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -40451,6 +40454,7 @@
     "@redhat-cloud-services/compliance-client": {
       "version": "file:packages/compliance",
       "requires": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }
@@ -40486,6 +40490,7 @@
     "@redhat-cloud-services/integrations-client": {
       "version": "file:packages/integrations",
       "requires": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }
@@ -40500,6 +40505,7 @@
     "@redhat-cloud-services/notifications-client": {
       "version": "file:packages/notifications",
       "requires": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
         "axios": "^0.27.2",
         "tslib": "^2.6.2"
       }

--- a/packages/compliance/package.json
+++ b/packages/compliance/package.json
@@ -24,6 +24,7 @@
     "generate:prod": "SPEC='https://cloud.redhat.com/api/compliance/v2/openapi.json' npm run generate"
   },
   "dependencies": {
+    "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
     "axios": "^0.27.2",
     "tslib": "^2.6.2"
   }


### PR DESCRIPTION
Noticed the shared package was missing from Compliance client
![image](https://github.com/RedHatInsights/javascript-clients/assets/20592948/4a616e0a-1eb8-4311-afba-aece9da78745)
Make a new compliance release please
