### PR TITLE
Update commitMessageFormat for nacho-bot

### DIFF
--- a/packages/compliance/README.md
+++ b/packages/compliance/README.md
@@ -1,5 +1,5 @@
 # Javascript client for the compliance API
-If you want to use [RedHatInsights/compliance](https://github.com/RedHatInsights/compliance) you shouldn't use get requests directly, but rather use this client to integrate with the service.
+If you want to use [RedHatInsights/compliance](https://github.com/RedHatInsights/compliance) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM

--- a/packages/compliance/project.json
+++ b/packages/compliance/project.json
@@ -34,7 +34,8 @@
       "executor": "@jscutlery/semver:version",
       "options": {
         "push": true,
-        "preset": "conventionalcommits"
+        "preset": "conventionalcommits",
+        "commitMessageFormat": "release: bump {projectName} to {version} [skip ci]"
       }
     },
     "github": {


### PR DESCRIPTION
This _should_ fix the issue. Previously after a successful merge before, another GH action run from nacho-bot for compliance-client would run with incorrect tags for other clients causing a release step failure. 