### PR TITLE
Prevent plural deletion when generating on OSX

### DIFF
--- a/postProcess.sh
+++ b/postProcess.sh
@@ -3,7 +3,7 @@
 # https://unix.stackexchange.com/questions/13711/differences-between-sed-on-mac-osx-and-other-standard-sed
 if [[ "$OSTYPE" == "darwin"* ]]; then
   # remove trailing whitespace
-  sed -i '' 's/\s*$//' $1
+  sed -i '' 's/ *$//' $1
 
   # https://github.com/OpenAPITools/openapi-generator/issues/2154
   sed -i '' 's/OneOfResolutionsboolean/Resolutions \| boolean/' $1


### PR DESCRIPTION
For [RHCLOUD-32914](https://issues.redhat.com/browse/RHCLOUD-32914). Turns out the issue is in the `postProcess.sh` file specifically for OSX that runs for all our generators 🥴  unblocks https://github.com/RedHatInsights/javascript-clients/pull/262