### PR TITLE
Update javascript-clients-shared version in rbac-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33762,10 +33762,10 @@
     },
     "packages/rbac": {
       "name": "@redhat-cloud-services/rbac-client",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
         "axios": "^1.7.2",
         "tslib": "^2.6.2"
       }
@@ -40678,7 +40678,7 @@
     "@redhat-cloud-services/rbac-client": {
       "version": "file:packages/rbac",
       "requires": {
-        "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
         "axios": "^1.7.2",
         "tslib": "^2.6.2"
       },

--- a/packages/rbac/package.json
+++ b/packages/rbac/package.json
@@ -21,7 +21,7 @@
     "doc": "typedoc"
   },
   "dependencies": {
-    "@redhat-cloud-services/javascript-clients-shared": "^1.2.2",
+    "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
     "axios": "^1.7.2",
     "tslib": "^2.6.2"
   }


### PR DESCRIPTION
`rbac-client` was using an old version of js-clients-shared with an out of date Axios version for [RHCLOUD-34295](https://issues.redhat.com/browse/RHCLOUD-34295). 