### PR TITLE
Using correct version for actions/setup-java

### DIFF
--- a/.github/workflows/sync-apis.yml
+++ b/.github/workflows/sync-apis.yml
@@ -27,7 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - name: Install Java and Maven
-      uses: actions/setup-java@4
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'


### PR DESCRIPTION
Updating to use the correct version for `actions/setup-java`.

Fear the pacman!  :v    :ghost: 