### PR TITLE
Update client generation cronjob

### DIFF
--- a/.github/workflows/sync-apis.yml
+++ b/.github/workflows/sync-apis.yml
@@ -6,8 +6,6 @@ name: Syncing APIs and Generating Clients
 on:
   schedule:
     - cron: "0 0 * * *"
-  push:
-    branches: [ "main" ]
 
 
 jobs:
@@ -38,7 +36,7 @@ jobs:
     - name: Build packages
       run: npm run build:no-cache
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.BOT_GH_TOKEN }}
         title: 'chore(nightly-sync): API sync and client generation'


### PR DESCRIPTION
Update client generation cronjob to only run once a day and use the latest version of PR creation action.