### PR TITLE
Update docs for compliance and config-manager-client

### DIFF
--- a/packages/compliance/README.md
+++ b/packages/compliance/README.md
@@ -18,20 +18,19 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/compliance-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/compliance-client/utils'; 
+import createEndpoint from '@redhat-cloud-services/compliance-client/AssignRule';
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const complianceApi = APIFactory(BASE_PATH, undefined, { AssignRule });
+export complianceApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
 // api.js
 import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/compliance-client';
+import { complianceApi } from '@redhat-cloud-services/compliance-client';
 const instance = axios.create();
 
 // Request interceptor
@@ -50,8 +49,8 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const complianceApi = APIFactory(BASE_PATH, instance, { AssignRule });
+export complianceApi;
 ```
 
 ## Building

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -18,20 +18,19 @@ This client is using typescript and axios. Types are distributed with this packa
 To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
 ```JS
 // api.js
-import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/config-manager-client';
-const instance = axios.create();
+import APIFactory from '@redhat-cloud-services/config-manager-client/utils'; 
+import createEndpoint from '@redhat-cloud-services/config-manager-client/CreateProfile';
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const configManagerApi = APIFactory(BASE_PATH, undefined, { CreateProfile });
+export configManagerApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
 // api.js
 import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/host-inventory-client';
+import { configManagerApi } from '@redhat-cloud-services/config-manager-client';
 const instance = axios.create();
 
 // Request interceptor
@@ -50,8 +49,8 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const configManagerApi = APIFactory(BASE_PATH, instance, { CreateProfile });
+export configManagerApi;
 ```
 
 ## Building


### PR DESCRIPTION
We had some release [failures](https://github.com/RedHatInsights/javascript-clients/actions/runs/11738666735/job/32701722152) that resulted in version bumps, but not actual package releases. This caused NX to have a cached GH version that didn't actually exist. I've deleted the tags in GH which should allow these two packages to create their tags properly and then release on NPM.