### PR TITLE
Update shared API factory library return type to be AxiosResponse

### DIFF
--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,6 +1,6 @@
 import { BaseAPI } from './base';
 import { ActionType, ApiConfig, RequestArgs } from './common';
-import globalAxios from 'axios';
+import globalAxios, { AxiosResponse } from 'axios';
 
 function isAxiosConfigObject(arg: any): arg is ApiConfig {
   return arg && typeof arg === 'object' && 'axios' in arg;
@@ -10,8 +10,10 @@ function isActionConfigObject(arg: any): arg is Record<string, ActionType> {
   return arg && typeof arg === 'object';
 }
 
-export function APIFactory<T extends Record<string, ActionType>>(basePath: string, actions: T, config?: ApiConfig): BaseAPI & T;
-export function APIFactory<T extends Record<string, ActionType>>(actions: T, config?: ApiConfig): BaseAPI & T;
+export type APIFactoryResponse<J extends Record<string, ActionType>> = { [K in keyof J]: (...args: J[K] extends (...args: infer A) => any ? A : never) => Promise<AxiosResponse<unknown, any>>};
+
+export function APIFactory<T extends Record<string, ActionType>>(basePath: string, actions: T, config?: ApiConfig): BaseAPI & APIFactoryResponse<T>;
+export function APIFactory<T extends Record<string, ActionType>>(actions: T, config?: ApiConfig): BaseAPI & APIFactoryResponse<T>;
 export function APIFactory<T extends Record<string, ActionType>>(...args: unknown[]) {
   const [a, b, c] = args;
   let basePath: string | undefined = undefined;
@@ -43,5 +45,5 @@ export function APIFactory<T extends Record<string, ActionType>>(...args: unknow
     });
   }
 
-  return api as BaseAPI & T;
+  return api as BaseAPI & APIFactoryResponse<T>;
 }

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,6 +1,6 @@
 import { BaseAPI } from './base';
 import { ActionType, ApiConfig, RequestArgs } from './common';
-import globalAxios, { AxiosResponse } from 'axios';
+import globalAxios from 'axios';
 
 function isAxiosConfigObject(arg: any): arg is ApiConfig {
   return arg && typeof arg === 'object' && 'axios' in arg;
@@ -10,11 +10,20 @@ function isActionConfigObject(arg: any): arg is Record<string, ActionType> {
   return arg && typeof arg === 'object';
 }
 
-export type APIFactoryResponse<J extends Record<string, ActionType>> = { [K in keyof J]: (...args: J[K] extends (...args: infer A) => any ? A : never) => Promise<AxiosResponse<unknown, any>>};
+export type APIFactoryResponse<J extends Record<string, ActionType>, L extends { [K in keyof J]: unknown }> = {
+  [K in keyof J]: (...args: J[K] extends (...args: infer A) => any ? A : never) => L[K];
+};
 
-export function APIFactory<T extends Record<string, ActionType>>(basePath: string, actions: T, config?: ApiConfig): BaseAPI & APIFactoryResponse<T>;
-export function APIFactory<T extends Record<string, ActionType>>(actions: T, config?: ApiConfig): BaseAPI & APIFactoryResponse<T>;
-export function APIFactory<T extends Record<string, ActionType>>(...args: unknown[]) {
+export function APIFactory<T extends Record<string, ActionType>, S extends { [K in keyof T]: unknown }>(
+  basePath: string,
+  actions: T,
+  config?: ApiConfig,
+): BaseAPI & APIFactoryResponse<T, S>;
+export function APIFactory<T extends Record<string, ActionType>, S extends { [K in keyof T]: unknown }>(
+  actions: T,
+  config?: ApiConfig,
+): BaseAPI & APIFactoryResponse<T, S>;
+export function APIFactory<T extends Record<string, ActionType>, S extends { [K in keyof T]: unknown }>(...args: unknown[]) {
   const [a, b, c] = args;
   let basePath: string | undefined = undefined;
   let actions: Record<string, ActionType> = {};
@@ -45,5 +54,5 @@ export function APIFactory<T extends Record<string, ActionType>>(...args: unknow
     });
   }
 
-  return api as BaseAPI & APIFactoryResponse<T>;
+  return api as BaseAPI & APIFactoryResponse<T, S>;
 }

--- a/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
@@ -4,12 +4,18 @@ import type { AxiosStatic } from 'axios'
 import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared/dist/utils';
 import { ApiConfig } from '@redhat-cloud-services/javascript-clients-shared/dist/common'
 import {
-{{>endpointList}}  } from './index';
+{{>endpointImports}}  } from './index';
+
+const endpointList = {
+  {{>endpointList}}
+};
+
+type endpointReturnTypes = {
+  {{>endpointTypes}}
+};
 
 export const {{{clientName}}} = (BASE_PATH: string, instance?: ApiConfig) => {
-  return APIFactory(BASE_PATH, {
-{{>endpointList}}  },
-  instance);
+  return APIFactory<typeof endpointList, endpointReturnTypes>(BASE_PATH, endpointList, instance);
 }
 
 export default {{{clientName}}};

--- a/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
@@ -53,6 +53,8 @@ export type {{operationIdCamelCase}}{{enumName}} = typeof {{operationIdCamelCase
 
 {{#operations}}
 {{#operation}}
+export type {{operationIdCamelCase}}ReturnType = AxiosPromise<{{{returnType}}}{{^returnType}}void{{/returnType}}>;
+
 const is{{operationIdCamelCase}}ObjectParams = (params: [{{operationIdCamelCase}}Params] | unknown[]): params is [{{operationIdCamelCase}}Params] => {
   return params.length === 1{{#allParams}} && {{^required}}true{{/required}}{{#required}}Object.prototype.hasOwnProperty.call(params, '{{paramName}}'){{/required}}{{/allParams}}
 }

--- a/src/main/resources/typescript-axios-webpack-module-federation/endpointImports.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/endpointImports.mustache
@@ -1,0 +1,2 @@
+{{#apiInfo.apis}}{{#operations}}{{#operation}}    {{nickname}},{{operationIdCamelCase}}ReturnType,
+{{/operation}}{{/operations}}{{/apiInfo.apis}}

--- a/src/main/resources/typescript-axios-webpack-module-federation/endpointTypes.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/endpointTypes.mustache
@@ -1,0 +1,2 @@
+{{#apiInfo.apis}}{{#operations}}{{#operation}}    {{nickname}}: {{operationIdCamelCase}}ReturnType,
+{{/operation}}{{/operations}}{{/apiInfo.apis}}

--- a/src/main/resources/typescript-axios-webpack-module-federation/index.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/index.mustache
@@ -1,12 +1,8 @@
-// This is a sample supporting file mustache template.
-
 {{#apiInfo.apis}}
 {{#operations}}
 {{#operation}}
-export { default as {{nickname}} } from './{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}'
+export { default as {{nickname}}, {{operationIdCamelCase}}ReturnType } from './{{#lambda.titlecase}}{{operationId}}{{/lambda.titlecase}}'
 
 {{/operation}}
-
-// end of operations block
 {{/operations}}
 {{/apiInfo.apis}}


### PR DESCRIPTION
~~**Still a WIP - we need to address the actual return object type in `AxiosResponse` - right now it is just `unknown` - but it should be what the OpenAPI spec specifies.**~~ 

Update: I was able to get the return type to match the OpenAPI spec now too.

This was not a trivial change as we are trying to use generics for all the clients. There are still some improvements to be had we will look into later. I'm open to making whatever export/data structure changes we see fit.

To test:
1. Build generator `npm run build:generator`
1. Build javascript-client-shared `npm run nx -- run @redhat-cloud-services/javascript-clients-shared:build --skip-nx-cache`
1. Generate host-inventory `npm run nx -- run @redhat-cloud-services/host-inventory-client:generate --skip-nx-cache`
1. In host-inventory - create a file called `test.ts`. This will use the `api.ts` file we just generated. The contents of `test.ts` should be:
```ts
import { HostInventoryClient } from './api';
import { ApiGroupCreateGroupParams } from './ApiGroupCreateGroup';

const client = HostInventoryClient('www.redhat.com');

const opts: ApiGroupCreateGroupParams = { groupIn: {} };

const response = client.apiGroupCreateGroup(opts);

response.then(val => {
    console.log(val.data.org_id);
});
```

![image](https://github.com/user-attachments/assets/77edb5cf-1768-44e2-ab08-891525805921)


