### PR TITLE
Update compliance-client README with new api usage

### DIFF
--- a/packages/compliance/README.md
+++ b/packages/compliance/README.md
@@ -15,22 +15,29 @@ yarn add @redhat-cloud-services/compliance-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import APIFactory from '@redhat-cloud-services/compliance-client/utils'; 
-import createEndpoint from '@redhat-cloud-services/compliance-client/AssignRule';
+`import ComplianceClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+ComplianceClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/compliance-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const complianceApi = APIFactory(BASE_PATH, undefined, { AssignRule });
+const complianceApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
 export complianceApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { complianceApi } from '@redhat-cloud-services/compliance-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/compliance-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -49,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const complianceApi = APIFactory(BASE_PATH, instance, { AssignRule });
+const complianceApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
 export complianceApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/compliance-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/compliance-client` to build the library.
+Run `nx run @redhat-cloud-services/compliance-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/compliance-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/compliance-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/entitlements/README.md
+++ b/packages/entitlements/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Inventory API
-If you want to use [RedHatInsights/entitlements-api](https://github.com/RedHatInsights/entitlements-api) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+# Javascript client for the entitlements API
+If you want to use [RedHatInsights/entitlements](https://github.com/RedHatInsights/entitlements) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/entitlements-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { ActionApi } from '@redhat-cloud-services/entitlements-client';
-const instance = axios.create();
+`import entitlementsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+entitlementsClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/entitlements-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const actionAPI = new ActionApi(undefined, BASE_PATH, instance);
-export actionAPI;
+const entitlementsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export entitlementsApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { ActionApi } from '@redhat-cloud-services/entitlements-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/entitlements-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const actionAPI = new ActionApi(undefined, BASE_PATH, instance);
-export actionAPI;
+const entitlementsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export entitlementsApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/entitlements-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/entitlements-client` to build the library.
+Run `nx run @redhat-cloud-services/entitlements-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/entitlements-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/entitlements-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/host-inventory/README.md
+++ b/packages/host-inventory/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Inventory API
-If you want to use [RedHatInsights/insights-host-inventory](https://github.com/RedHatInsights/insights-host-inventory) you shouldn't use get requests directly, but rather use this client to integrate with inventory service.
+# Javascript client for the host-inventory API
+If you want to use [RedHatInsights/host-inventory](https://github.com/RedHatInsights/host-inventory) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/host-inventory-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { HostsApi } from '@redhat-cloud-services/host-inventory-client';
-const instance = axios.create();
+`import host-inventoryClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+host-inventoryClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/host-inventory-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const hostsApi = new HostsApi(undefined, BASE_PATH, instance);
-export hostsApi;
+const hostInventoryApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export hostInventoryApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { HostsApi } from '@redhat-cloud-services/host-inventory-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/host-inventory-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const hostsApi = new HostsApi(undefined, BASE_PATH, instance);
-export hostsApi;
+const hostInventoryApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export hostInventoryApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/host-inventory-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/host-inventory-client` to build the library.
+Run `nx run @redhat-cloud-services/host-inventory-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/host-inventory-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/host-inventory-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/insights/README.md
+++ b/packages/insights/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Insights API
-If you want to use [RedHatInsights/insights-advisor-api](https://github.com/RedHatInsights/insights-advisor-api) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+# Javascript client for the insights API
+If you want to use [RedHatInsights/insights](https://github.com/RedHatInsights/insights) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/insights-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { GroupApi } from '@redhat-cloud-services/insights-client';
-const instance = axios.create();
+`import insightsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+insightsClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/insights-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const groupApi = new GroupApi(undefined, BASE_PATH, instance);
-export groupApi;
+const insightsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export insightsApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { SystemApi } from '@redhat-cloud-services/insights-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/insights-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const systemApi = new SystemApi(undefined, BASE_PATH, instance);
-export systemApi;
+const insightsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export insightsApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/insights-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/insights-client` to build the library.
+Run `nx run @redhat-cloud-services/insights-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/insights-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/insights-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Integrations API
-If you want to use [RedHatInsights/notifications-backend](https://github.com/RedHatInsights/notifications-backend) you shouldn't use get requests directly, but rather use this client to integrate with the service.
+# Javascript client for the integrations API
+If you want to use [RedHatInsights/integrations](https://github.com/RedHatInsights/integrations) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/integrations-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import APIFactory from '@redhat-cloud-services/integrations-client/utils'; 
-import createEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1CreateEndpoint';
-import enableEndpoint from '@redhat-cloud-services/integrations-client/endpointResourceV1EnableEndpoint';
+`import integrationsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+integrationsClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/integrations-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = APIFactory(BASE_PATH, undefined, { createEndpoint, enableEndpoint });
+const integrationsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
 export integrationsApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { IntegrationsApi } from '@redhat-cloud-services/integrations-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/integrations-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const integrationsApi = APIFactory(BASE_PATH, instance, { createEndpoint, enableEndpoint });
+const integrationsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
 export integrationsApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/integrations-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/integrations-client` to build the library.
+Run `nx run @redhat-cloud-services/integrations-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/integrations-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/integrations-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Notifications API
-If you want to use [RedHatInsights/notifications-backend](https://github.com/RedHatInsights/notifications-backend) you shouldn't use get requests directly, but rather use this client to integrate with the service.
+# Javascript client for the notifications API
+If you want to use [RedHatInsights/notifications](https://github.com/RedHatInsights/notifications) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,25 +15,29 @@ yarn add @redhat-cloud-services/notifications-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import APIFactory from '@redhat-cloud-services/notifications-client/utils'; 
-import createBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1CreateBehaviorGroup';
-import updateBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1UpdateBehaviorGroup';
-import deleteBehaviorGroup from '@redhat-cloud-services/notifications-client/NotificationResourceV1DeleteBehaviorGroup';
+`import notificationsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
 
+notificationsClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/notifications-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = APIFactory(BASE_PATH, undefined, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
+const notificationsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
 export notificationsApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { NotificationsApi } from '@redhat-cloud-services/notifications-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/notifications-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -52,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const notificationsApi = APIFactory(BASE_PATH, instance, { createBehaviorGroup, updateBehaviorGroup, deleteBehaviorGroup });
+const notificationsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
 export notificationsApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/notifications-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/notifications-client` to build the library.
+Run `nx run @redhat-cloud-services/notifications-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/notifications-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/notifications-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/patch/README.md
+++ b/packages/patch/README.md
@@ -1,10 +1,75 @@
+# Javascript client for the patch API
+If you want to use [RedHatInsights/patch](https://github.com/RedHatInsights/patch) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+
+## Install
+NPM
+```bash
+npm install --save @redhat-cloud-services/patch-client
+```
+
+Or Yarn
+```bash
+yarn add @redhat-cloud-services/patch-client
+```
+
+### Usage
+This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
+
+This package comes with a client in its `api.ts` already defined with every call available. 
+```JS
+`import patchClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+patchClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/patch-client/ExampleEndpoint';
+
+// BASE_PATH should be set in your constants file
+const patchApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export patchApi;
+```
+
+If you want to add some interceptors you can use axios build in interceptors
+```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/patch-client/ExampleEndpoint';
+
+const instance = axios.create();
+
+// Request interceptor
+instance.interceptors.request.use((request) => {
+    // some logic to do with request
+});
+
+// Response interceptor
+instance.interceptors.response.use((response) => {
+    // some logic to do with request
+});
+
+// Error interceptor
+instance.interceptors.response.use(null, (error) => {
+    // some logic to do with error
+});
+
+// BASE_PATH should be set in your constants file
+const patchApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export patchApi;
+```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/patch-client:generate` to generate the package.
+
 ## Building
 
-Run `nx build @redhat-cloud-services/patch-client` to build the library.
+Run `nx run @redhat-cloud-services/patch-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/patch-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/patch-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/policies/README.md
+++ b/packages/policies/README.md
@@ -1,10 +1,75 @@
+# Javascript client for the policies API
+If you want to use [RedHatInsights/policies](https://github.com/RedHatInsights/policies) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+
+## Install
+NPM
+```bash
+npm install --save @redhat-cloud-services/policies-client
+```
+
+Or Yarn
+```bash
+yarn add @redhat-cloud-services/policies-client
+```
+
+### Usage
+This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
+
+This package comes with a client in its `api.ts` already defined with every call available. 
+```JS
+`import policiesClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+policiesClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/policies-client/ExampleEndpoint';
+
+// BASE_PATH should be set in your constants file
+const policiesApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export policiesApi;
+```
+
+If you want to add some interceptors you can use axios build in interceptors
+```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/policies-client/ExampleEndpoint';
+
+const instance = axios.create();
+
+// Request interceptor
+instance.interceptors.request.use((request) => {
+    // some logic to do with request
+});
+
+// Response interceptor
+instance.interceptors.response.use((response) => {
+    // some logic to do with request
+});
+
+// Error interceptor
+instance.interceptors.response.use(null, (error) => {
+    // some logic to do with error
+});
+
+// BASE_PATH should be set in your constants file
+const policiesApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export policiesApi;
+```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/policies-client:generate` to generate the package.
+
 ## Building
 
-Run `nx build @redhat-cloud-services/policies-client` to build the library.
+Run `nx run @redhat-cloud-services/policies-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/policies-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/policies-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/quickstarts/README.md
+++ b/packages/quickstarts/README.md
@@ -1,10 +1,75 @@
+# Javascript client for the quickstarts API
+If you want to use [RedHatInsights/quickstarts](https://github.com/RedHatInsights/quickstarts) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+
+## Install
+NPM
+```bash
+npm install --save @redhat-cloud-services/quickstarts-client
+```
+
+Or Yarn
+```bash
+yarn add @redhat-cloud-services/quickstarts-client
+```
+
+### Usage
+This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
+
+This package comes with a client in its `api.ts` already defined with every call available. 
+```JS
+`import quickstartsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+quickstartsClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/quickstarts-client/ExampleEndpoint';
+
+// BASE_PATH should be set in your constants file
+const quickstartsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export quickstartsApi;
+```
+
+If you want to add some interceptors you can use axios build in interceptors
+```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/quickstarts-client/ExampleEndpoint';
+
+const instance = axios.create();
+
+// Request interceptor
+instance.interceptors.request.use((request) => {
+    // some logic to do with request
+});
+
+// Response interceptor
+instance.interceptors.response.use((response) => {
+    // some logic to do with request
+});
+
+// Error interceptor
+instance.interceptors.response.use(null, (error) => {
+    // some logic to do with error
+});
+
+// BASE_PATH should be set in your constants file
+const quickstartsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export quickstartsApi;
+```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/quickstarts-client:generate` to generate the package.
+
 ## Building
 
-Run `nx build @redhat-cloud-services/quickstarts-client` to build the library.
+Run `nx run @redhat-cloud-services/quickstarts-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/quickstarts-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/quickstarts-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/rbac/README.md
+++ b/packages/rbac/README.md
@@ -1,4 +1,5 @@
-# Javascript client for RBAC API
+# Javascript client for the rbac API
+If you want to use [RedHatInsights/rbac](https://github.com/RedHatInsights/rbac) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -14,20 +15,31 @@ yarn add @redhat-cloud-services/rbac-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from "axios";
-import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared'; 
-import getGroup from "@redhat-cloud-services/rbac-client/dist/GetGroup";
+`import rbacClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+rbacClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/rbac-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const instance = axios.create();
-const rbacApi = APIFactory(BASE_PATH, { getGroup }, instance);
+const rbacApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
 export rbacApi;
 ```
-And if you want to add some interceptors to the axios instance:
+
+If you want to add some interceptors you can use axios build in interceptors
 ```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/rbac-client/ExampleEndpoint';
+
+const instance = axios.create();
+
 // Request interceptor
 instance.interceptors.request.use((request) => {
     // some logic to do with request
@@ -44,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const rbacApi = APIFactory(BASE_PATH, { getGroup }, instance);
+const rbacApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
 export rbacApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/rbac-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/rbac-client` to build the library.
+Run `nx run @redhat-cloud-services/rbac-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/rbac-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/rbac-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/remediations/README.md
+++ b/packages/remediations/README.md
@@ -1,42 +1,75 @@
+# Javascript client for the remediations API
+If you want to use [RedHatInsights/remediations](https://github.com/RedHatInsights/remediations) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
-Javascript client for Remediations API
-=======================================
-
-This is a client library for [RedHatInsights/insights-remediations](https://github.com/RedHatInsights/insights-remediations).
-
-Install
--------
-
+## Install
 NPM
-
 ```bash
 npm install --save @redhat-cloud-services/remediations-client
 ```
 
 Or Yarn
-
 ```bash
 yarn add @redhat-cloud-services/remediations-client
 ```
 
 ### Usage
-
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-```js
-import { RemediationsApi } from '@redhat-cloud-services/remediations-client';
+This package comes with a client in its `api.ts` already defined with every call available. 
+```JS
+`import remediationsClient from '@redhat-cloud-services/javascript-clients-shared/utils';
 
-const api = new RemediationsApi();
-const remediations = await api.getRemediations();
+remediationsClient.someEndpoint();
 ```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/remediations-client/ExampleEndpoint';
+
+// BASE_PATH should be set in your constants file
+const remediationsApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export remediationsApi;
+```
+
+If you want to add some interceptors you can use axios build in interceptors
+```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/remediations-client/ExampleEndpoint';
+
+const instance = axios.create();
+
+// Request interceptor
+instance.interceptors.request.use((request) => {
+    // some logic to do with request
+});
+
+// Response interceptor
+instance.interceptors.response.use((response) => {
+    // some logic to do with request
+});
+
+// Error interceptor
+instance.interceptors.response.use(null, (error) => {
+    // some logic to do with error
+});
+
+// BASE_PATH should be set in your constants file
+const remediationsApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export remediationsApi;
+```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/remediations-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/remediations-client` to build the library.
+Run `nx run @redhat-cloud-services/remediations-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/remediations-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/remediations-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,39 +1,75 @@
-@redhat-cloud-services/javascript-clients-shared / [Exports](modules.md)
-
-# Shared Javascript utilities and functions for javascript-clients
-This package contains some common configurations and functions needed for clients using the new [javascript-clients](https://github.com/RedHatInsights/javascript-clients) generator. 
+# Javascript client for the shared API
+If you want to use [RedHatInsights/shared](https://github.com/RedHatInsights/shared) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
 ```bash
-npm install --save @redhat-cloud-services/javascript-clients-shared
+npm install --save @redhat-cloud-services/shared-client
 ```
 
 Or Yarn
 ```bash
-yarn add @redhat-cloud-services/javascript-clients-shared
+yarn add @redhat-cloud-services/shared-client
 ```
 
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import APIFactory from '@redhat-cloud-services/javascript-clients-shared'; 
+`import sharedClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+sharedClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/shared-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const someApi = APIFactory(BASE_PATH, undefined, { createEndpoint, enableEndpoint });
-export someApi;
+const sharedApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export sharedApi;
 ```
+
+If you want to add some interceptors you can use axios build in interceptors
+```JS
+import axios from 'axios';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/shared-client/ExampleEndpoint';
+
+const instance = axios.create();
+
+// Request interceptor
+instance.interceptors.request.use((request) => {
+    // some logic to do with request
+});
+
+// Response interceptor
+instance.interceptors.response.use((response) => {
+    // some logic to do with request
+});
+
+// Error interceptor
+instance.interceptors.response.use(null, (error) => {
+    // some logic to do with error
+});
+
+// BASE_PATH should be set in your constants file
+const sharedApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export sharedApi;
+```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/shared-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/javascript-clients-shared` to build the library.
+Run `nx run @redhat-cloud-services/shared-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/javascript-clients-shared` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/shared-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 

--- a/packages/sources/README.md
+++ b/packages/sources/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Sources API
-If you want to use [ManageIQ/sources-api](https://github.com/ManageIQ/sources-api) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+# Javascript client for the sources API
+If you want to use [RedHatInsights/sources](https://github.com/RedHatInsights/sources) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/sources-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { DefaultApi } from '@redhat-cloud-services/sources-client';
-const instance = axios.create();
+`import sourcesClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+sourcesClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/sources-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const baseApi = new DefaultApi(undefined, BASE_PATH, instance);
-export baseApi;
+const sourcesApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export sourcesApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { DefaultApi } from '@redhat-cloud-services/catalog-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/sources-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,19 +56,21 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const baseApi = new DefaultApi(undefined, BASE_PATH, instance);
-export baseApi;
+const sourcesApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export sourcesApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/sources-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/sources-client` to build the library.
+Run `nx run @redhat-cloud-services/sources-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/sources-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/sources-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 
 * [README](doc/README.md)
-

--- a/packages/topological-inventory/README.md
+++ b/packages/topological-inventory/README.md
@@ -1,5 +1,5 @@
-# Javascript client for Topological inventory API
-If you want to use [ManageIQ/topological-inventory-api](https://github.com/ManageIQ/https://github.com/ManageIQ/topological_inventory-api) you shouldn't use get requests directly, but rather use this client to integrate with this service.
+# Javascript client for the topological-inventory API
+If you want to use [RedHatInsights/topological-inventory](https://github.com/RedHatInsights/topological-inventory) you shouldn't use get requests directly, but rather use this client to integrate with this service.
 
 ## Install
 NPM
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/topological-inventory-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { DefaultApi } from '@redhat-cloud-services/topological-inventory-client';
-const instance = axios.create();
+`import topological-inventoryClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+topological-inventoryClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/topological-inventory-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const baseApi = new DefaultApi(undefined, BASE_PATH, instance);
-export baseApi;
+const topologicalInventoryApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export topologicalInventoryApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { DefaultApi } from '@redhat-cloud-services/topological-inventory-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/topological-inventory-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,20 +56,21 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const baseApi = new DefaultApi(undefined, BASE_PATH, instance);
-export baseApi;
+const topologicalInventoryApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export topologicalInventoryApi;
 ```
+## Generating
 
-## API documentation
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/topological-inventory-client:generate` to generate the package.
+
 ## Building
 
-Run `nx build @redhat-cloud-services/topological-inventory-client` to build the library.
+Run `nx run @redhat-cloud-services/topological-inventory-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/topological-inventory-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/topological-inventory-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 
 * [README](doc/README.md)
-

--- a/utils/nx-base/README.md
+++ b/utils/nx-base/README.md
@@ -15,23 +15,29 @@ yarn add @redhat-cloud-services/CLIENTNAME-client
 ### Usage
 This client is using typescript and axios. Types are distributed with this package, so no need to define or install them separately.
 
-To correctly bootstrap this API you should use this config (no need to define it multiple times, just one config and reimport it anywhere you want to use it).
+This package comes with a client in its `api.ts` already defined with every call available. 
 ```JS
-// api.js
-import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/CLIENTNAME-client';
-const instance = axios.create();
+`import CLIENTNAMEClient from '@redhat-cloud-services/javascript-clients-shared/utils';
+
+CLIENTNAMEClient.someEndpoint();
+```
+
+To bootstrap this API manually, you should create your own client via the `APIFactory` defined in the `@redhat-cloud-services/javascript-clients-shared` package. See below for an example:
+```JS
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils'; 
+import exampleEndpoint from '@redhat-cloud-services/CLIENTNAME-client/ExampleEndpoint';
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const CLIENTNAMEApi = APIFactory(BASE_PATH, undefined, { exampleEndpoint });
+export CLIENTNAMEApi;
 ```
 
 If you want to add some interceptors you can use axios build in interceptors
 ```JS
-// api.js
 import axios from 'axios';
-import { Configuration } from '@redhat-cloud-services/CLIENTNAME-client';
+import APIFactory from '@redhat-cloud-services/javascript-clients-shared/utils';
+import exampleEndpoint from '@redhat-cloud-services/CLIENTNAME-client/ExampleEndpoint';
+
 const instance = axios.create();
 
 // Request interceptor
@@ -50,17 +56,20 @@ instance.interceptors.response.use(null, (error) => {
 });
 
 // BASE_PATH should be set in your constants file
-const configApi = new Configuration(undefined, BASE_PATH, instance);
-export configApi;
+const CLIENTNAMEApi = APIFactory(BASE_PATH, instance, { exampleEndpoint });
+export CLIENTNAMEApi;
 ```
+## Generating
+
+Ensure you have the javascript-clients generator built first with `npm run build:generator`. Then, run `nx run @redhat-cloud-services/CLIENTNAME-client:generate` to generate the package.
 
 ## Building
 
-Run `nx build @redhat-cloud-services/CLIENTNAME-client` to build the library.
+Run `nx run @redhat-cloud-services/CLIENTNAME-client:build` to build the package. This creates the `dist` for publishing.
 
 ## Running unit tests
 
-Run `nx test @redhat-cloud-services/CLIENTNAME-client` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx run @redhat-cloud-services/CLIENTNAME-client:test` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## API documentation
 


### PR DESCRIPTION
~~Using this as a first-pass for the new `api.ts` usage README. Once this gets merged, I'll open another PR for the rest of the clients' READMEs as they'll need this usage update too.~~ 

Updated READMEs for all clients (minus vulnerabilities as it still is on the old generator) with the new `api.ts` usage.