### PR TITLE
notifications api client tests

### DIFF
--- a/packages/notifications/jest.config.ts
+++ b/packages/notifications/jest.config.ts
@@ -7,4 +7,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/packages/notifications',
+  testPathIgnorePatterns: ['/node_modules/','/tests/integration/'],
 };

--- a/packages/notifications/jest.integration.v1.config.ts
+++ b/packages/notifications/jest.integration.v1.config.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export default {
+  displayName: 'notifications-client',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[t]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.integration.v1.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js'],
+  coverageDirectory: '../../coverage/packages/notifications',
+  testEnvironmentOptions: {
+    testEnvironment: 'node',
+    url: "http://localhost:3001",
+  },
+  testMatch: ['**/notifications.v1.integration.test.ts']
+};

--- a/packages/notifications/jest.integration.v2.config.ts
+++ b/packages/notifications/jest.integration.v2.config.ts
@@ -1,0 +1,15 @@
+/* eslint-disable */
+export default {
+  displayName: 'notifications-client',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[t]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.integration.v2.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js'],
+  coverageDirectory: '../../coverage/packages/notifications',
+  testEnvironmentOptions: {
+    testEnvironment: 'node',
+    url: "http://localhost:3002",
+  },
+  testMatch: ['**/notifications.v2.integration.test.ts']
+};

--- a/packages/notifications/project.json
+++ b/packages/notifications/project.json
@@ -47,6 +47,27 @@
         "commitMessageFormat": "release: bump {projectName} to {version} [skip ci]"
       }
     },
+    "integration-v2": {
+      "command": "start-server-and-test 'bin/serve.sh https://console.redhat.com/api/notifications/v2/openapi.json 3002' http://localhost:3002/api/notifications/v2.0/notifications/bundles/bob 'nx run --verbose @redhat-cloud-services/notifications-client:jest-v2'"
+    },
+    "integration-v1": {
+      "command": "start-server-and-test 'bin/serve.sh https://console.redhat.com/api/notifications/v1.0/openapi.json 3001' http://localhost:3001/api/notifications/v1.0/notifications/bundles/bob 'nx run --verbose @redhat-cloud-services/notifications-client:jest-v1'"
+    },
+    "jest-v2": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/notifications/jest.integration.v2.config.ts"
+      },
+      "parallelism": false
+    },
+    "jest-v1": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "packages/notifications/jest.integration.v1.config.ts"
+      }
+    },
     "github": {
       "executor": "@jscutlery/semver:github",
       "options": {

--- a/packages/notifications/tests/integration/notifications.v1.integration.test.ts
+++ b/packages/notifications/tests/integration/notifications.v1.integration.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { NotificationsClient } from '../../api';
+import { DrawerResourceV1GetDrawerEntriesParams } from '../../DrawerResourceV1GetDrawerEntries';
+import { EventResourceV1GetEventsParams } from '../../EventResourceV1GetEvents';
+import { DrawerResourceV1UpdateNotificationReadStatusParams } from '../../DrawerResourceV1UpdateNotificationReadStatus';
+import { NotificationResourceV1CreateBehaviorGroupParams } from '../../NotificationResourceV1CreateBehaviorGroup';
+import { CreateBehaviorGroupRequest } from '../../types';
+import { NotificationResourceV1DeleteBehaviorGroupParams } from '../../NotificationResourceV1DeleteBehaviorGroup';
+import { UpdateBehaviorGroupRequest } from '../../v2/types';
+import { NotificationResourceV1UpdateBehaviorGroupParams } from '../../NotificationResourceV1UpdateBehaviorGroup';
+import { NotificationResourceV1DeleteBehaviorGroupFromEventTypeParams } from '../../NotificationResourceV1DeleteBehaviorGroupFromEventType';
+import { NotificationResourceV1GetBehaviorGroupsAffectedByRemovalOfEndpointParams } from '../../NotificationResourceV1GetBehaviorGroupsAffectedByRemovalOfEndpoint';
+import { NotificationResourceV1UpdateBehaviorGroupActionsParams } from '../../NotificationResourceV1UpdateBehaviorGroupActions';
+import { OrgConfigResourceV1GetDailyDigestTimePreferenceParams } from '../../OrgConfigResourceV1GetDailyDigestTimePreference';
+import { OrgConfigResourceV1SaveDailyDigestTimePreferenceParams } from '../../OrgConfigResourceV1SaveDailyDigestTimePreference';
+import { NotificationResourceV1GetEventTypesParams } from '../../NotificationResourceV1GetEventTypes';
+import { NotificationResourceV1UpdateEventTypeEndpointsParams } from '../../NotificationResourceV1UpdateEventTypeEndpoints';
+import { NotificationResourceV1GetEventTypesAffectedByRemovalOfBehaviorGroupParams } from '../../NotificationResourceV1GetEventTypesAffectedByRemovalOfBehaviorGroup';
+import { NotificationResourceV1GetEventTypesByNameAndBundleAndApplicationNameParams } from '../../NotificationResourceV1GetEventTypesByNameAndBundleAndApplicationName';
+import { NotificationResourceV1UpdateEventTypeBehaviorsParams } from '../../NotificationResourceV1UpdateEventTypeBehaviors';
+import { NotificationResourceV1AppendBehaviorGroupToEventTypeParams } from '../../NotificationResourceV1AppendBehaviorGroupToEventType';
+import { NotificationResourceV1FindBehaviorGroupsByBundleIdParams } from '../../NotificationResourceV1FindBehaviorGroupsByBundleId';
+import { NotificationResourceV1GetApplicationByNameAndBundleNameParams } from '../../NotificationResourceV1GetApplicationByNameAndBundleName';
+import { NotificationResourceV1GetApplicationsFacetsParams } from '../../NotificationResourceV1GetApplicationsFacets';
+import { NotificationResourceV1GetBundleByNameParams } from '../../NotificationResourceV1GetBundleByName';
+import { NotificationResourceV1GetBundleFacetsParams } from '../../NotificationResourceV1GetBundleFacets';
+
+const BASE_PATH = 'http://localhost:3001/api/notifications/v1.0';
+const client = NotificationsClient(BASE_PATH);
+
+describe('Notifications API (v1)', () => {
+  test('get drawer entries', async () => {
+    const params: DrawerResourceV1GetDrawerEntriesParams = {};
+    const resp = await client.drawerResourceV1GetDrawerEntries(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get events', async () => {
+    const params: EventResourceV1GetEventsParams = {};
+    const resp = await client.eventResourceV1GetEvents(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update notification read status', async () => {
+    const params: DrawerResourceV1UpdateNotificationReadStatusParams = {};
+    const resp = await client.drawerResourceV1UpdateNotificationReadStatus(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('create behavior group', async () => {
+    const createBehaviorGroupRequest: CreateBehaviorGroupRequest = {
+      display_name: 'test name',
+    };
+    const params: NotificationResourceV1CreateBehaviorGroupParams = { createBehaviorGroupRequest };
+    const resp = await client.notificationResourceV1CreateBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('delete behavior group', async () => {
+    const params: NotificationResourceV1DeleteBehaviorGroupParams = { id: '1' };
+    const resp = await client.notificationResourceV1DeleteBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('find behavior groups by bundle id', async () => {
+    const params: NotificationResourceV1FindBehaviorGroupsByBundleIdParams = { bundleId: '1' };
+    const resp = await client.notificationResourceV1FindBehaviorGroupsByBundleId(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update behavior group', async () => {
+    const updateBehaviorGroupRequest: UpdateBehaviorGroupRequest = {
+      display_name: 'updated name',
+    };
+    const params: NotificationResourceV1UpdateBehaviorGroupParams = { id: '1', updateBehaviorGroupRequest };
+    const resp = await client.notificationResourceV1UpdateBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('delete behavior group from event type', async () => {
+    const params: NotificationResourceV1DeleteBehaviorGroupFromEventTypeParams = { behaviorGroupId: '12', eventTypeId: '13' };
+    const resp = await client.notificationResourceV1DeleteBehaviorGroupFromEventType(params);
+    expect(resp.status).toBe(204);
+  });
+
+  test('get behavior groups affected by removal of endpoint', async () => {
+    const params: NotificationResourceV1GetBehaviorGroupsAffectedByRemovalOfEndpointParams = {
+      endpointId: '1',
+    };
+    const resp = await client.notificationResourceV1GetBehaviorGroupsAffectedByRemovalOfEndpoint(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update behavior group actions', async () => {
+    const params: NotificationResourceV1UpdateBehaviorGroupActionsParams = {
+      behaviorGroupId: 'behaviorGroupId',
+    };
+    const resp = await client.notificationResourceV1UpdateBehaviorGroupActions(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('append behavior group to event type', async () => {
+    const params: NotificationResourceV1AppendBehaviorGroupToEventTypeParams = { behaviorGroupUuid: '1', eventTypeUuid: '1' };
+    const resp = await client.notificationResourceV1AppendBehaviorGroupToEventType(params);
+    expect(resp.status).toBe(204);
+  });
+
+  test('org config - get daily digest time pref', async () => {
+    const params: OrgConfigResourceV1GetDailyDigestTimePreferenceParams = {};
+    const resp = await client.orgConfigResourceV1GetDailyDigestTimePreference(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('org config - save daily digest time pref', async () => {
+    const params: OrgConfigResourceV1SaveDailyDigestTimePreferenceParams = {};
+    const resp = await client.orgConfigResourceV1SaveDailyDigestTimePreference(params);
+    expect(resp.status).toBe(204);
+  });
+
+  test('get event types', async () => {
+    const params: NotificationResourceV1GetEventTypesParams = {};
+    const resp = await client.notificationResourceV1GetEventTypes(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update event types endpoints', async () => {
+    const params: NotificationResourceV1UpdateEventTypeEndpointsParams = { eventTypeId: '1' };
+    const resp = await client.notificationResourceV1UpdateEventTypeEndpoints(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types by name and bundle and application name', async () => {
+    const params: NotificationResourceV1GetEventTypesByNameAndBundleAndApplicationNameParams = {
+      applicationName: 'appName',
+      bundleName: 'bundleName',
+      eventTypeName: 'eventTypeName',
+    };
+    const resp = await client.notificationResourceV1GetEventTypesByNameAndBundleAndApplicationName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update event type behaviors', async () => {
+    const params: NotificationResourceV1UpdateEventTypeBehaviorsParams = {
+      eventTypeId: 'eventTypeId',
+    };
+    const resp = await client.notificationResourceV1UpdateEventTypeBehaviors(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types affected by removal of behavior group', async () => {
+    const params: NotificationResourceV1GetEventTypesAffectedByRemovalOfBehaviorGroupParams = {
+      behaviorGroupId: '1',
+    };
+    const resp = await client.notificationResourceV1GetEventTypesAffectedByRemovalOfBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types by name and bundle and application name', async () => {
+    const params: NotificationResourceV1GetEventTypesByNameAndBundleAndApplicationNameParams = {
+      applicationName: 'appName',
+      bundleName: 'bundleName',
+      eventTypeName: 'eventTypeName',
+    };
+    const resp = await client.notificationResourceV1GetEventTypesByNameAndBundleAndApplicationName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get application by name and bundle name', async () => {
+    const params: NotificationResourceV1GetApplicationByNameAndBundleNameParams = { applicationName: 'appName', bundleName: 'bundleName' };
+    const resp = await client.notificationResourceV1GetApplicationByNameAndBundleName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get application facets', async () => {
+    const params: NotificationResourceV1GetApplicationsFacetsParams = { bundleName: 'bundleName' };
+    const resp = await client.notificationResourceV1GetApplicationsFacets(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get bundle by name', async () => {
+    const params: NotificationResourceV1GetBundleByNameParams = {
+      bundleName: 'bundleName',
+    };
+    const resp = await client.notificationResourceV1GetBundleByName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get bundle facets', async () => {
+    const params: NotificationResourceV1GetBundleFacetsParams = {};
+    const resp = await client.notificationResourceV1GetBundleFacets(params);
+    expect(resp.status).toBe(200);
+  });
+});

--- a/packages/notifications/tsconfig.integration.v1.spec.json
+++ b/packages/notifications/tsconfig.integration.v1.spec.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "packages/notifications/tests/integrations/notifications.v1.test.ts"
+  ],
+  "exclude": ["packages/notifications/v2/tests/integration/notifications.v2.test.ts"]
+}

--- a/packages/notifications/tsconfig.integration.v2.spec.json
+++ b/packages/notifications/tsconfig.integration.v2.spec.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "packages/notifications/v2/tests/integration/notifications.v2.integration.test.ts"
+  ]
+}

--- a/packages/notifications/v2/tests/integration/notifications.v2.integration.test.ts
+++ b/packages/notifications/v2/tests/integration/notifications.v2.integration.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from '@jest/globals';
+
+import { NotificationsClient } from '../../api';
+import { EventResourceV2GetEventsParams } from '../../EventResourceV2GetEvents';
+import { NotificationResourceV2AppendBehaviorGroupToEventTypeParams } from '../../NotificationResourceV2AppendBehaviorGroupToEventType';
+import { NotificationResourceV2CreateBehaviorGroupParams } from '../../NotificationResourceV2CreateBehaviorGroup';
+import { CreateBehaviorGroupRequest, UpdateBehaviorGroupRequest } from '../../types';
+import { NotificationResourceV2GetEventTypesParams } from '../../NotificationResourceV2GetEventTypes';
+import { NotificationResourceV2DeleteBehaviorGroupParams } from '../../NotificationResourceV2DeleteBehaviorGroup';
+import { NotificationResourceV2FindBehaviorGroupsByBundleIdParams } from '../../NotificationResourceV2FindBehaviorGroupsByBundleId';
+import { NotificationResourceV2GetApplicationByNameAndBundleNameParams } from '../../NotificationResourceV2GetApplicationByNameAndBundleName';
+import { NotificationResourceV2GetApplicationsFacetsParams } from '../../NotificationResourceV2GetApplicationsFacets';
+import { NotificationResourceV2GetBundleByNameParams } from '../../NotificationResourceV2GetBundleByName';
+import { NotificationResourceV2GetBundleFacetsParams } from '../../NotificationResourceV2GetBundleFacets';
+import { NotificationResourceV2UpdateBehaviorGroupParams } from '../../NotificationResourceV2UpdateBehaviorGroup';
+import { NotificationResourceV2UpdateEventTypeEndpointsParams } from '../../NotificationResourceV2UpdateEventTypeEndpoints';
+import { NotificationResourceV2DeleteBehaviorGroupFromEventTypeParams } from '../../NotificationResourceV2DeleteBehaviorGroupFromEventType';
+import { NotificationResourceV2GetBehaviorGroupsAffectedByRemovalOfEndpointParams } from '../../NotificationResourceV2GetBehaviorGroupsAffectedByRemovalOfEndpoint';
+import { NotificationResourceV2GetLinkedBehaviorGroupsParams } from '../../NotificationResourceV2GetLinkedBehaviorGroups';
+import { NotificationResourceV2GetEventTypesAffectedByRemovalOfBehaviorGroupParams } from '../../NotificationResourceV2GetEventTypesAffectedByRemovalOfBehaviorGroup';
+import { NotificationResourceV2GetEventTypesByNameAndBundleAndApplicationNameParams } from '../../NotificationResourceV2GetEventTypesByNameAndBundleAndApplicationName';
+import { NotificationResourceV2UpdateBehaviorGroupActionsParams } from '../../NotificationResourceV2UpdateBehaviorGroupActions';
+import { NotificationResourceV2UpdateEventTypeBehaviorsParams } from '../../NotificationResourceV2UpdateEventTypeBehaviors';
+import { OrgConfigResourceV2SaveDailyDigestTimePreferenceParams } from '../../OrgConfigResourceV2SaveDailyDigestTimePreference';
+import { OrgConfigResourceV2GetDailyDigestTimePreferenceParams } from '../../OrgConfigResourceV2GetDailyDigestTimePreference';
+
+const BASE_PATH = 'http://localhost:3002/api/notifications/v2.0';
+const client = NotificationsClient(BASE_PATH);
+
+describe('Notifications API (v2)', () => {
+  test('get events', async () => {
+    const params: EventResourceV2GetEventsParams = {};
+    const resp = await client.eventResourceV2GetEvents(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('append behavior group to event type', async () => {
+    const params: NotificationResourceV2AppendBehaviorGroupToEventTypeParams = { behaviorGroupUuid: '1', eventTypeUuid: '1' };
+    const resp = await client.notificationResourceV2AppendBehaviorGroupToEventType(params);
+    expect(resp.status).toBe(204);
+  });
+
+  test('create behavior group', async () => {
+    const createBehaviorGroupRequest: CreateBehaviorGroupRequest = {
+      display_name: 'test name',
+    };
+    const params: NotificationResourceV2CreateBehaviorGroupParams = { createBehaviorGroupRequest };
+    const resp = await client.notificationResourceV2CreateBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types', async () => {
+    const params: NotificationResourceV2GetEventTypesParams = {};
+    const resp = await client.notificationResourceV2GetEventTypes(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('delete behavior group', async () => {
+    const params: NotificationResourceV2DeleteBehaviorGroupParams = { id: '1' };
+    const resp = await client.notificationResourceV2DeleteBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('find behavior groups by bundle id', async () => {
+    const params: NotificationResourceV2FindBehaviorGroupsByBundleIdParams = { bundleId: '1' };
+    const resp = await client.notificationResourceV2FindBehaviorGroupsByBundleId(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get application by name and bundle name', async () => {
+    const params: NotificationResourceV2GetApplicationByNameAndBundleNameParams = { applicationName: 'appName', bundleName: 'bundleName' };
+    const resp = await client.notificationResourceV2GetApplicationByNameAndBundleName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get application facets', async () => {
+    const params: NotificationResourceV2GetApplicationsFacetsParams = { bundleName: 'bundleName' };
+    const resp = await client.notificationResourceV2GetApplicationsFacets(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get bundle by name', async () => {
+    const params: NotificationResourceV2GetBundleByNameParams = {
+      bundleName: 'bundleName',
+    };
+    const resp = await client.notificationResourceV2GetBundleByName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get bundle facets', async () => {
+    const params: NotificationResourceV2GetBundleFacetsParams = {};
+    const resp = await client.notificationResourceV2GetBundleFacets(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update behavior group', async () => {
+    const updateBehaviorGroupRequest: UpdateBehaviorGroupRequest = {
+      display_name: 'updated name',
+    };
+    const params: NotificationResourceV2UpdateBehaviorGroupParams = { id: '1', updateBehaviorGroupRequest };
+    const resp = await client.notificationResourceV2UpdateBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update event types endpoints', async () => {
+    const params: NotificationResourceV2UpdateEventTypeEndpointsParams = { eventTypeId: '1' };
+    const resp = await client.notificationResourceV2UpdateEventTypeEndpoints(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('delete behavior group from event type', async () => {
+    const params: NotificationResourceV2DeleteBehaviorGroupFromEventTypeParams = { behaviorGroupId: '12', eventTypeId: '13' };
+    const resp = await client.notificationResourceV2DeleteBehaviorGroupFromEventType(params);
+    expect(resp.status).toBe(204);
+  });
+
+  test('get behavior groups affected by removal of endpoint', async () => {
+    const params: NotificationResourceV2GetBehaviorGroupsAffectedByRemovalOfEndpointParams = {
+      endpointId: '1',
+    };
+    const resp = await client.notificationResourceV2GetBehaviorGroupsAffectedByRemovalOfEndpoint(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get linked behavior groups', async () => {
+    const params: NotificationResourceV2GetLinkedBehaviorGroupsParams = {
+      eventTypeId: '1',
+    };
+    const resp = await client.notificationResourceV2GetLinkedBehaviorGroups(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types affected by removal of behavior group', async () => {
+    const params: NotificationResourceV2GetEventTypesAffectedByRemovalOfBehaviorGroupParams = {
+      behaviorGroupId: '1',
+    };
+    const resp = await client.notificationResourceV2GetEventTypesAffectedByRemovalOfBehaviorGroup(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('get event types by name and bundle and application name', async () => {
+    const params: NotificationResourceV2GetEventTypesByNameAndBundleAndApplicationNameParams = {
+      applicationName: 'appName',
+      bundleName: 'bundleName',
+      eventTypeName: 'eventTypeName',
+    };
+    const resp = await client.notificationResourceV2GetEventTypesByNameAndBundleAndApplicationName(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update behavior group actions', async () => {
+    const params: NotificationResourceV2UpdateBehaviorGroupActionsParams = {
+      behaviorGroupId: 'behaviorGroupId',
+    };
+    const resp = await client.notificationResourceV2UpdateBehaviorGroupActions(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('update event type behaviors', async () => {
+    const params: NotificationResourceV2UpdateEventTypeBehaviorsParams = {
+      eventTypeId: 'eventTypeId',
+    };
+    const resp = await client.notificationResourceV2UpdateEventTypeBehaviors(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('org config - get daily digest time pref', async () => {
+    const params: OrgConfigResourceV2GetDailyDigestTimePreferenceParams = {};
+    const resp = await client.orgConfigResourceV2GetDailyDigestTimePreference(params);
+    expect(resp.status).toBe(200);
+  });
+
+  test('org config - save daily digest time pref', async () => {
+    const params: OrgConfigResourceV2SaveDailyDigestTimePreferenceParams = {};
+    const resp = await client.orgConfigResourceV2SaveDailyDigestTimePreference(params);
+    expect(resp.status).toBe(204);
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/RedHatInsights/javascript-clients/pull/341.

Establishes test coverage for Notifications API v1 and v2.

