### PR TITLE
Update rbac-client v2 spec name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35061,7 +35061,7 @@
     },
     "packages/compliance": {
       "name": "@redhat-cloud-services/compliance-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35086,7 +35086,7 @@
     },
     "packages/config-manager": {
       "name": "@redhat-cloud-services/config-manager-client",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35111,7 +35111,7 @@
     },
     "packages/entitlements": {
       "name": "@redhat-cloud-services/entitlements-client",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35136,7 +35136,7 @@
     },
     "packages/host-inventory": {
       "name": "@redhat-cloud-services/host-inventory-client",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35161,7 +35161,7 @@
     },
     "packages/insights": {
       "name": "@redhat-cloud-services/insights-client",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35186,7 +35186,7 @@
     },
     "packages/integrations": {
       "name": "@redhat-cloud-services/integrations-client",
-      "version": "3.2.0",
+      "version": "3.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35211,7 +35211,7 @@
     },
     "packages/notifications": {
       "name": "@redhat-cloud-services/notifications-client",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35236,7 +35236,7 @@
     },
     "packages/patch": {
       "name": "@redhat-cloud-services/patch-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35261,7 +35261,7 @@
     },
     "packages/policies": {
       "name": "@redhat-cloud-services/policies-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35286,7 +35286,7 @@
     },
     "packages/quickstarts": {
       "name": "@redhat-cloud-services/quickstarts-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35311,7 +35311,7 @@
     },
     "packages/rbac": {
       "name": "@redhat-cloud-services/rbac-client",
-      "version": "3.0.1",
+      "version": "3.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35336,7 +35336,7 @@
     },
     "packages/remediations": {
       "name": "@redhat-cloud-services/remediations-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35361,7 +35361,7 @@
     },
     "packages/shared": {
       "name": "@redhat-cloud-services/javascript-clients-shared",
-      "version": "1.2.6",
+      "version": "1.2.7",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.2",
@@ -35385,7 +35385,7 @@
     },
     "packages/sources": {
       "name": "@redhat-cloud-services/sources-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35410,7 +35410,7 @@
     },
     "packages/topological-inventory": {
       "name": "@redhat-cloud-services/topological-inventory-client",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",

--- a/packages/rbac/project.json
+++ b/packages/rbac/project.json
@@ -9,7 +9,7 @@
       "options": {
         "specs": {
           "default": "https://raw.githubusercontent.com/RedHatInsights/insights-rbac/master/docs/source/specs/openapi.json",
-          "v2": "https://raw.githubusercontent.com/RedHatInsights/insights-rbac/master/docs/source/specs/v2/openapi.v2.yaml"
+          "v2": "https://raw.githubusercontent.com/RedHatInsights/insights-rbac/master/docs/source/specs/v2/openapi.yaml"
         }
       }
     },

--- a/packages/rbac/types/index.ts
+++ b/packages/rbac/types/index.ts
@@ -402,7 +402,7 @@ export interface CrossAccountRequestIn {
      * @type {string}
      * @memberof CrossAccountRequestIn
      */
-    'target_account': string;
+    'target_account'?: string;
     /**
      *
      * @type {string}


### PR DESCRIPTION
The `v2` spec for rbac is no longer valid as it was renamed. This PR also updates the client with the new spec changes.