### PR TITLE
RHCLOUD-37159: Remove tests of non-public Integrations v1 endpoints

### DIFF
--- a/packages/integrations/tests/integration/integrations.v1.integration.test.ts
+++ b/packages/integrations/tests/integration/integrations.v1.integration.test.ts
@@ -14,7 +14,6 @@ import { EndpointResourceV1GetOrCreateDrawerSubscriptionEndpointParams } from '.
 import { EndpointResourceV1GetOrCreateEmailSubscriptionEndpointParams } from '../../EndpointResourceV1GetOrCreateEmailSubscriptionEndpoint';
 import { EndpointResourceV1UpdateEndpointParams } from '../../EndpointResourceV1UpdateEndpoint';
 import { EndpointResourceV1UpdateEventTypesLinkedToEndpointParams } from '../../EndpointResourceV1UpdateEventTypesLinkedToEndpoint';
-import { AxiosError } from 'axios';
 
 // note the 1.0, which is different from, for example, RBAC v1
 const BASE_PATH = 'http://localhost:3001/api/integrations/v1.0/';
@@ -40,12 +39,7 @@ describe('Integrations API (v1)', () => {
     const deleteEndpointParams: EndpointResourceV1DeleteEndpointParams = {
       id: placeHolder,
     };
-    const deleteEndpointResp = await client.endpointResourceV1DeleteEndpoint(deleteEndpointParams).catch((error: AxiosError) => {
-      expect(error.message).toContain('404');
-    });
-    if (!deleteEndpointResp) {
-      return;
-    }
+    const deleteEndpointResp = await client.endpointResourceV1DeleteEndpoint(deleteEndpointParams);
     expect(deleteEndpointResp.status).toEqual(204);
   });
 
@@ -59,12 +53,7 @@ describe('Integrations API (v1)', () => {
 
   test('disable endpoint', async () => {
     const disableEndpointParams: EndpointResourceV1DisableEndpointParams = { id: placeHolder };
-    const disableResp = await client.endpointResourceV1DisableEndpoint(disableEndpointParams).catch((error: AxiosError) => {
-      expect(error).toContain('404');
-    });
-    if (!disableResp) {
-      return;
-    }
+    const disableResp = await client.endpointResourceV1DisableEndpoint(disableEndpointParams);
     expect(disableResp.status).toEqual(204);
   });
 

--- a/packages/integrations/tests/integration/integrations.v1.integration.test.ts
+++ b/packages/integrations/tests/integration/integrations.v1.integration.test.ts
@@ -3,8 +3,6 @@ import { describe, expect, test } from '@jest/globals';
 import { IntegrationsClient } from '../../api';
 import { EndpointResourceV1CreateEndpointParams } from '../../EndpointResourceV1CreateEndpoint';
 import { Endpoint, EndpointType, RequestSystemSubscriptionProperties } from '../../types';
-import { EndpointResourceV1AddEventTypeToEndpointParams } from '../../EndpointResourceV1AddEventTypeToEndpoint';
-import { EndpointResourceV1DeleteEventTypeFromEndpointParams } from '../../EndpointResourceV1DeleteEventTypeFromEndpoint';
 import { EndpointResourceV1DeleteEndpointParams } from '../../EndpointResourceV1DeleteEndpoint';
 import { EndpointResourceV1EnableEndpointParams } from '../../EndpointResourceV1EnableEndpoint';
 import { EndpointResourceV1DisableEndpointParams } from '../../EndpointResourceV1DisableEndpoint';
@@ -36,48 +34,6 @@ describe('Integrations API (v1)', () => {
     };
     const createEndpointResp = await client.endpointResourceV1CreateEndpoint(endpointResourceV1CreateEndpointParams);
     expect(createEndpointResp.status).toEqual(200);
-  });
-
-  test('add event type from endpoint params', async () => {
-    const addEventTypeParams: EndpointResourceV1AddEventTypeToEndpointParams = {
-      endpointId: placeHolder,
-      eventTypeId: placeHolder,
-    };
-    const addEventTypeResp = await client.endpointResourceV1AddEventTypeToEndpoint(addEventTypeParams).catch((error: AxiosError) => {
-      expect(error.message).toContain('404');
-    });
-    if (!addEventTypeResp) {
-      return;
-    }
-    expect(addEventTypeResp.status).toEqual(204);
-  });
-
-  test('remove event type from endpoint params', async () => {
-    const removeEventTypeParams: EndpointResourceV1DeleteEventTypeFromEndpointParams = {
-      endpointId: placeHolder,
-      eventTypeId: placeHolder,
-    };
-    const removeEventTypeResp = await client.endpointResourceV1DeleteEventTypeFromEndpoint(removeEventTypeParams).catch((error: AxiosError) => {
-      expect(error.message).toContain('404');
-    });
-    if (!removeEventTypeResp) {
-      return;
-    }
-    expect(removeEventTypeResp).toEqual(204);
-  });
-
-  test('delete event type from endpoint', async () => {
-    const deleteEventTypeParams: EndpointResourceV1DeleteEventTypeFromEndpointParams = {
-      endpointId: placeHolder,
-      eventTypeId: placeHolder,
-    };
-    const deleteEventTypeResp = await client.endpointResourceV1DeleteEventTypeFromEndpoint(deleteEventTypeParams).catch((error: AxiosError) => {
-      expect(error.message).toContain('404');
-    });
-    if (!deleteEventTypeResp) {
-      return;
-    }
-    expect(deleteEventTypeResp.status).toEqual(204);
   });
 
   test('delete endpoint', async () => {


### PR DESCRIPTION
Related to RHCLOUD-37161

We have some tests that consume out-of-date endpoints (removed from the spec but not the generated client). This PR deletes the associated tests.