### PR TITLE
feat!: release version 3.0.0 of quickstarts in prep for new builder

### DIFF
--- a/packages/quickstarts/package.json
+++ b/packages/quickstarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/quickstarts-client",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",


### PR DESCRIPTION
We will be making breaking changes to the directory structure of the clients by switching to the new builder (which supports both commonjs and esm builds).

Using this PR to test if nacho bot will create a github tag and release for us when using `!` after `feat`.