### PR TITLE
feat!: Update quickstarts to use new builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35186,7 +35186,7 @@
     },
     "packages/integrations": {
       "name": "@redhat-cloud-services/integrations-client",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35286,7 +35286,7 @@
     },
     "packages/quickstarts": {
       "name": "@redhat-cloud-services/quickstarts-client",
-      "version": "2.0.2",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",
@@ -35311,7 +35311,7 @@
     },
     "packages/rbac": {
       "name": "@redhat-cloud-services/rbac-client",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/javascript-clients-shared": "^1.2.6",

--- a/packages/quickstarts/package.json
+++ b/packages/quickstarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/quickstarts-client",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",

--- a/packages/quickstarts/project.json
+++ b/packages/quickstarts/project.json
@@ -13,11 +13,12 @@
       }
     },
     "build": {
-      "executor": "@redhat-cloud-services/build-utils:old-builder",
+      "executor": "@redhat-cloud-services/build-utils:builder",
       "options": {
         "outputPath": "packages/quickstarts/dist",
         "main": "packages/quickstarts/index.ts",
-        "tsConfig": "packages/quickstarts/tsconfig.cjs.json"
+        "esmTsConfig": "packages/quickstarts/tsconfig.esm.json",
+        "cjsTsConfig": "packages/quickstarts/tsconfig.cjs.json"
       }
     },
     "publish": {
@@ -56,8 +57,7 @@
     "npm": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "access": "public",
-        "distFolderPath": "dist/quickstarts"
+        "access": "public"
       }
     }
   },


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/RHCLOUD-32282 (convert clients to the new builder and support esm and cjs builds).