### PR TITLE
refactor(RHINENG-18217): add type to group API

### DIFF
--- a/packages/host-inventory/ApiGroupGetGroupList/index.ts
+++ b/packages/host-inventory/ApiGroupGetGroupList/index.ts
@@ -19,6 +19,12 @@ export type ApiGroupGetGroupListParams = {
   */
   name?: string,
   /**
+  * Filter by group type
+  * @type { ApiGroupGetGroupListTypeEnum }
+  * @memberof ApiGroupGetGroupListApi
+  */
+  type?: ApiGroupGetGroupListTypeEnum,
+  /**
   * A number of items to return per page.
   * @type { number }
   * @memberof ApiGroupGetGroupListApi
@@ -48,6 +54,16 @@ export type ApiGroupGetGroupListParams = {
   * @export
   * @enum {string}
   */
+export const ApiGroupGetGroupListTypeEnum = {
+    All: 'all',
+    Standard: 'standard',
+    Ungrouped: 'ungrouped-hosts'
+} as const;
+export type ApiGroupGetGroupListTypeEnum = typeof ApiGroupGetGroupListTypeEnum[keyof typeof ApiGroupGetGroupListTypeEnum];
+/**
+  * @export
+  * @enum {string}
+  */
 export const ApiGroupGetGroupListOrderByEnum = {
     Name: 'name',
     HostCount: 'host_count',
@@ -67,7 +83,7 @@ export type ApiGroupGetGroupListOrderHowEnum = typeof ApiGroupGetGroupListOrderH
 export type ApiGroupGetGroupListReturnType = AxiosPromise<GroupQueryOutput>;
 
 const isApiGroupGetGroupListObjectParams = (params: [ApiGroupGetGroupListParams] | unknown[]): params is [ApiGroupGetGroupListParams] => {
-  return params.length === 1 && true && true && true && true && true
+  return params.length === 1 && true && true && true && true && true && true
 }
 /**
 * Read the entire list of all groups available to the account. <br /><br /> Required permissions: inventory:groups:read
@@ -76,9 +92,9 @@ const isApiGroupGetGroupListObjectParams = (params: [ApiGroupGetGroupListParams]
 * @param {*} [options] Override http request option.
 * @throws {RequiredError}
 */
-export const apiGroupGetGroupListParamCreator = async (...config: ([ApiGroupGetGroupListParams] | [string, number, number, ApiGroupGetGroupListOrderByEnum, ApiGroupGetGroupListOrderHowEnum, AxiosRequestConfig])): Promise<RequestArgs> => {
-    const params = isApiGroupGetGroupListObjectParams(config) ? config[0] : ['name', 'perPage', 'page', 'orderBy', 'orderHow', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as ApiGroupGetGroupListParams;
-    const { name, perPage, page, orderBy, orderHow, options = {} } = params;
+export const apiGroupGetGroupListParamCreator = async (...config: ([ApiGroupGetGroupListParams] | [string, ApiGroupGetGroupListTypeEnum, number, number, ApiGroupGetGroupListOrderByEnum, ApiGroupGetGroupListOrderHowEnum, AxiosRequestConfig])): Promise<RequestArgs> => {
+    const params = isApiGroupGetGroupListObjectParams(config) ? config[0] : ['name', 'type', 'perPage', 'page', 'orderBy', 'orderHow', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as ApiGroupGetGroupListParams;
+    const { name, type, perPage, page, orderBy, orderHow, options = {} } = params;
     const localVarPath = `/groups`;
     // use dummy base URL string because the URL constructor only accepts absolute URLs.
     const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -88,6 +104,10 @@ export const apiGroupGetGroupListParamCreator = async (...config: ([ApiGroupGetG
 
     if (name !== undefined) {
         localVarQueryParameter['name'] = name;
+    }
+
+    if (type !== undefined) {
+        localVarQueryParameter['type'] = type;
     }
 
     if (perPage !== undefined) {


### PR DESCRIPTION
This PR is related to [RHINENG-18217](https://issues.redhat.com/browse/RHINENG-18217).

Add `type` to `ApiGroupGetGroupListParams` so that it can be passed by the frontend when `kessel-migration` flag is enabled.