### PR TITLE
RHCLOUD-41072: Error handling when jq is missing

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -15,7 +15,7 @@
 # The server runs on localhost port 3000 by default. Can be overridden using arg 2.
 #
 
-
+set -e
 if ! command -v jq; then
     echo "This script requires jq; install and try again"
     exit 1

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -15,6 +15,12 @@
 # The server runs on localhost port 3000 by default. Can be overridden using arg 2.
 #
 
+
+if ! command -v jq; then
+    echo "This script requires jq; install and try again"
+    exit 1
+fi
+
 # Clean up temp files
 rm -f /tmp/workspaces.json
 rm -f /tmp/workspaces_updated.json


### PR DESCRIPTION
When `jq` isn't installed, the serve.sh script fails quietly. Make it fail loudly and explicitly.