### PR TITLE
fix: remove last-release baseline dependency from release workflow

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -27,7 +27,7 @@ runs:
         git config user.email "${{ inputs.gh_email }}"
     - name: Build
       shell: bash
-      run: npx nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client
+      run: npx nx affected --base=HEAD~1 -t build --trackDeps
     - name: Set publish config
       env:
         NPM_TOKEN: ${{ inputs.npm_token }}
@@ -38,10 +38,5 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.gh_token }}
         GITHUB_TOKEN: ${{ inputs.gh_token }}
-      run: npx nx affected --base=last-release --parallel=1 --target=version --postTargets=npm,github --trackDeps --exclude=@redhat-cloud-services/CLIENTNAME-client
-    - name: Tag last-release
-      shell: bash
-      run: |
-        git tag -f last-release
-        git push origin last-release --force
+      run: npx nx affected --base=HEAD~1 --parallel=1 --target=version --postTargets=npm,github --trackDeps
   

--- a/packages/rbac/package.json
+++ b/packages/rbac/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redhat-cloud-services/rbac-client",
   "version": "4.2.0",
-  "description": "",
+  "description": "TypeScript client for Red Hat Insights RBAC service",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "publishConfig": {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-42349

**Problem**
The release workflow was failing due to stale last-release tag baseline detection. The tag pointed to a January commit, causing the system to incorrectly calculate versions for packages already released in September, resulting in "tag already exists" errors that blocked new releases including rbac-client.

**Solution**
  - Replace `--base=last-release` with `--base=HEAD~1` in `nx affected` commands
  - Remove complex last-release tag management
  - Workflow now compares against the previous commit to reliably detect changed packages

**Result**
  - Fixes rbac-client release blocking (axios removal can now publish as v4.2.1)
  - Prevents future release failures from stale baseline detection
  - Simpler, more predictable release process