### PR TITLE
fix(build-utils): upgrade openapi-generator to 7.0.0, remove package-level configs

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "6.6.0"
+    "version": "7.0.0"
   }
 }

--- a/packages/build-utils/src/executors/client-generator/client-generator.spec.ts
+++ b/packages/build-utils/src/executors/client-generator/client-generator.spec.ts
@@ -1,10 +1,15 @@
 import { ExecutorContext } from '@nx/devkit';
 import { execSync } from 'child_process';
+import { existsSync } from 'node:fs';
 import generateClients, { ClientGeneratorSchemaType, validateSpec } from './client-generator';
 
 // Mock child_process
 jest.mock('child_process');
 const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+// Mock node:fs
+jest.mock('node:fs');
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
 
 // Mock console.error
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {
@@ -63,6 +68,8 @@ describe('generateClients', () => {
     // By default, validation succeeds (returns clean output)
     // execSync with { encoding: 'utf-8' } returns a string
     mockExecSync.mockReturnValue('No validation issues detected.' as any);
+    // By default, openapitools.json exists
+    mockExistsSync.mockReturnValue(true);
   });
 
   afterAll(() => {
@@ -433,10 +440,20 @@ describe('generateClients', () => {
       expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining("TS_POST_PROCESS_FILE='./postProcess.sh'"), { stdio: 'inherit' });
     });
 
-    it('should include openapitools.json path', async () => {
+    it('should include openapitools.json path when file exists', async () => {
+      mockExistsSync.mockReturnValue(true);
       await generateClients(mockOptions, mockContext);
 
       expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('--openapitools /workspace/test-project/openapitools.json'), {
+        stdio: 'inherit',
+      });
+    });
+
+    it('should omit openapitools.json path when file does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+      await generateClients(mockOptions, mockContext);
+
+      expect(mockExecSync).toHaveBeenCalledWith(expect.not.stringContaining('--openapitools'), {
         stdio: 'inherit',
       });
     });

--- a/packages/build-utils/src/executors/client-generator/client-generator.ts
+++ b/packages/build-utils/src/executors/client-generator/client-generator.ts
@@ -1,5 +1,6 @@
 import { ExecutorContext } from '@nx/devkit';
 import { execSync } from 'child_process';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 
@@ -50,8 +51,11 @@ function generateClient(packagePath: string, spec: string, outputDir: string, cl
       '--custom-generator=target/typescript-axios-webpack-module-federation-openapi-generator-1.0.0.jar -g typescript-axios-webpack-module-federation';
   }
 
+  const packageOpenapitools = join(packagePath, 'openapitools.json');
+  const openapiToolsArg = existsSync(packageOpenapitools) ? `--openapitools ${packageOpenapitools}` : '';
+
   execSync(
-    `TS_POST_PROCESS_FILE='./postProcess.sh' openapi-generator-cli generate -i ${spec} -o ${outputDir} --openapitools ${packagePath}/openapitools.json --skip-validate-spec --enable-post-process-file ${additionalArgs} --additional-properties clientName=${clientName}`,
+    `TS_POST_PROCESS_FILE='./postProcess.sh' openapi-generator-cli generate -i ${spec} -o ${outputDir} ${openapiToolsArg} --skip-validate-spec --enable-post-process-file ${additionalArgs} --additional-properties clientName=${clientName}`,
     { stdio: 'inherit' },
   );
 }

--- a/packages/compliance/openapitools.json
+++ b/packages/compliance/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "6.6.0"
-  }
-}

--- a/packages/config-manager/openapitools.json
+++ b/packages/config-manager/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.20.0"
-  }
-}

--- a/packages/entitlements/openapitools.json
+++ b/packages/entitlements/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/host-inventory/openapitools.json
+++ b/packages/host-inventory/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/insights/openapitools.json
+++ b/packages/insights/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/integrations/openapitools.json
+++ b/packages/integrations/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/notifications/openapitools.json
+++ b/packages/notifications/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/patch/openapitools.json
+++ b/packages/patch/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/quickstarts/openapitools.json
+++ b/packages/quickstarts/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/rbac/openapitools.json
+++ b/packages/rbac/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/remediations/openapitools.json
+++ b/packages/remediations/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/shared/openapitools.json
+++ b/packages/shared/openapitools.json
@@ -1,8 +1,0 @@
-
-{
-  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.4.0"
-  }
-}

--- a/packages/sources/openapitools.json
+++ b/packages/sources/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/topological-inventory/openapitools.json
+++ b/packages/topological-inventory/openapitools.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "7.0.0"
-  }
-}

--- a/packages/vulnerabilities/project.json
+++ b/packages/vulnerabilities/project.json
@@ -9,6 +9,7 @@
       "options": {
         "postProcess": "./postProcess.sh",
         "legacyGenerator": true,
+        "skipValidation": true,
         "specs": {
           "default": "apiSpec.json",
           "git-api": "apiSpec.json"

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <openapi-generator-version>6.6.0</openapi-generator-version>
+        <openapi-generator-version>7.0.0</openapi-generator-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.2</junit-version>
         <apache-commons-version>1.10.0</apache-commons-version>


### PR DESCRIPTION
Fixes "no main manifest attribute" error after clean install.

**Changes:**
- Upgrade custom JAR + root config to 7.0.0 (matches existing generated code)
- Remove 14 package-level openapitools.json (all inherit root 7.0.0)
- Keep vulnerabilities client at 4.3.1 (legacy generator)
- Update executor: conditional --openapitools flag
- Add skipValidation for vulnerabilities (upstream spec issues)

RHCLOUD-47336