### PR TITLE
build(templates): remove dist subpath from mustache templates

### DIFF
--- a/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
@@ -1,5 +1,3 @@
-/* tslint:disable */
-/* eslint-disable */
 import type { AxiosStatic } from 'axios'
 import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared/utils';
 import { ApiConfig } from '@redhat-cloud-services/javascript-clients-shared/common'

--- a/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
@@ -1,7 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
-import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared/dist/utils';
-import { ApiConfig } from '@redhat-cloud-services/javascript-clients-shared/dist/common'
+import type { AxiosStatic } from 'axios'
+import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared/utils';
+import { ApiConfig } from '@redhat-cloud-services/javascript-clients-shared/common'
 import {
 {{>endpointImports}}  } from './index';
 

--- a/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/api.mustache
@@ -1,4 +1,3 @@
-import type { AxiosStatic } from 'axios'
 import { APIFactory } from '@redhat-cloud-services/javascript-clients-shared/utils';
 import { ApiConfig } from '@redhat-cloud-services/javascript-clients-shared/common'
 import {

--- a/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
@@ -1,11 +1,11 @@
 // @ts-ignore
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig, Method } from 'axios';
 // @ts-ignore
-import { COLLECTION_FORMATS, RequiredError, AuthTypeEnum, DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '@redhat-cloud-services/javascript-clients-shared/dist/common';
-import type { RequestArgs } from '@redhat-cloud-services/javascript-clients-shared/dist/common';
+import { COLLECTION_FORMATS, RequiredError, AuthTypeEnum, DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '@redhat-cloud-services/javascript-clients-shared/common';
+import type { RequestArgs } from '@redhat-cloud-services/javascript-clients-shared/common';
 // @ts-ignore
-import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/base';
-import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
+import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/base';
+import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/configuration';
 
 // @ts-ignore
 import type { {{#imports}}{{classname}}{{^-last}}, {{/-last}}{{/imports}} } from '../types';

--- a/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
+++ b/src/main/resources/typescript-axios-webpack-module-federation/coreApi.mustache
@@ -1,13 +1,9 @@
-// @ts-ignore
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig, Method } from 'axios';
-// @ts-ignore
 import { COLLECTION_FORMATS, RequiredError, AuthTypeEnum, DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from '@redhat-cloud-services/javascript-clients-shared/common';
 import type { RequestArgs } from '@redhat-cloud-services/javascript-clients-shared/common';
-// @ts-ignore
 import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/base';
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/configuration';
 
-// @ts-ignore
 import type { {{#imports}}{{classname}}{{^-last}}, {{/-last}}{{/imports}} } from '../types';
 
 {{#models}}
@@ -27,7 +23,7 @@ export type {{operationIdCamelCase}}Params = {
   * @deprecated
 {{/deprecated}}
   */
-  {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}}, 
+  {{paramName}}{{^required}}?{{/required}}: {{#isEnum}}{{{datatypeWithEnum}}}{{/isEnum}}{{^isEnum}}{{{dataType}}}{{#isNullable}} | null{{/isNullable}}{{/isEnum}},
   {{/allParams}}
   options?: AxiosRequestConfig
 }
@@ -148,8 +144,8 @@ export const {{nickname}}ParamCreator = async (sendRequest: BaseAPI["sendRequest
         {{/isString}}
         {{^isString}}
         {{! isString is falsy also for $ref that defines a string or enum type}}
-        localVarHeaderParameter['{{baseName}}'] = typeof {{paramName}} === 'string' 
-            ? {{paramName}} 
+        localVarHeaderParameter['{{baseName}}'] = typeof {{paramName}} === 'string'
+            ? {{paramName}}
             : JSON.stringify({{paramName}});
         {{/isString}}
     }


### PR DESCRIPTION
### Description
  Removes `/* eslint-disable */`, `/* tslint:disable */`, and `// @ts-ignore` from mustache templates. Updates imports to use clean subpath exports from `javascript-clients-shared` (e.g., `shared/common` instead of `shared/dist/common`).

  Generated code now passes TypeScript compilation and ESLint without suppression comments. The `/dist/` path was an internal build artifact from the old builder; shared package v2 exports clean subpaths.

  [RHCLOUD-37737](https://issues.redhat.com/browse/RHCLOUD-37737)

  ---

  ### How to test locally
  1. Rebuild generator: `npm run build:generator`
  2. Regenerate a client: `npx nx run @redhat-cloud-services/entitlements-client:generate`
  3. Verify generated files have no `eslint-disable` or `tslint:disable` comments
  4. Verify imports use `@redhat-cloud-services/javascript-clients-shared/common` (not `/dist/common`)
  5. Verify build passes: `npx nx build @redhat-cloud-services/entitlements-client`
  6. Verify lint passes: `npx nx lint @redhat-cloud-services/entitlements-client`

  ---

  ### Anything reviewers should know?
  - **No breaking changes**: Existing generated client code unchanged until regeneration. External consumers never import from `/dist/` paths.
  - **Separate PR needed**: This only updates templates. All 15 client packages need regeneration (large diff, separate review).
  - **Shared package compatibility**: `javascript-clients-shared` exports both `/dist/*` (backward compat) and `/*` (canonical) paths. Regenerated clients use canonical
  paths.

  ---

  ### Checklist
  - [x] Tests: new/updated tests cover the change (N/A - template-only change, verified via manual regeneration)
  - [x] API: spec updated if endpoints changed (N/A)
  - [x] Migrations: backwards compatible if schema changed (N/A)
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (N/A)

  ### AI disclosure
  Assisted by: Claude Code

[RHCLOUD-37737]: https://redhat.atlassian.net/browse/RHCLOUD-37737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ