### PR TITLE
ci(security): SHA-pin actions, fix id-token scope, add environment protection

### DIFF
--- a/.github/actions/cypress-cache/action.yaml
+++ b/.github/actions/cypress-cache/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     # cache cypress runner 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: cypress-cache
       with:
         path: /home/runner/.cache/Cypress

--- a/.github/actions/lint/action.yaml
+++ b/.github/actions/lint/action.yaml
@@ -3,7 +3,7 @@ description: verify linting rules
 runs:
   using: "composite"
   steps:
-    - uses: nrwl/nx-set-shas@v4
+    - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
     - name: Install deps
       shell: bash
       run: npm ci

--- a/.github/actions/node-cache/action.yaml
+++ b/.github/actions/node-cache/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     # cache node modules for all jobs to use
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: node_modules-cache
       with:
         path: | 

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -18,12 +18,12 @@ runs:
         echo "=== Current Java ==="
         which java && java --version || echo "No default Java found"
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: 'temurin'
         java-version-file: '.java-version'
         cache: 'maven'
-    - uses: actions/setup-node@v5
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -3,7 +3,7 @@ description: Run API client integration tests against stubbed services
 runs:
   using: "composite"
   steps:
-    - uses: nrwl/nx-set-shas@v4
+    - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
     - name: integration test
       shell: bash
       run: npm run test:integration

--- a/.github/actions/test-unit/action.yaml
+++ b/.github/actions/test-unit/action.yaml
@@ -3,7 +3,7 @@ description: verify unit tests
 runs:
   using: "composite"
   steps:
-    - uses: nrwl/nx-set-shas@v4
+    - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
     - name: Install deps
       shell: bash
       run: npm ci

--- a/.github/actions/webpack-cache/action.yaml
+++ b/.github/actions/webpack-cache/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     # cache node modules for all jobs to use
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: webpack-cache
       with:
         path: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,15 @@ on:
 # Release job overrides with write permissions
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   install:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - uses: './.github/actions/setup-environment'
       # cache cypress runner
       - uses: './.github/actions/cypress-cache'
@@ -31,7 +30,7 @@ jobs:
     needs: [install]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -40,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [install]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -49,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [install]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
@@ -58,11 +57,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [install]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: './.github/actions/setup-environment'
-      - uses: nrwl/nx-set-shas@v4
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - name: Install deps
         run: npm ci
       - name: Build affected
@@ -74,11 +73,12 @@ jobs:
     needs: [install, lint, test, build]
     # Only run on push to main branch (never on PRs, workflow_dispatch, etc.)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: npm-publish
     permissions:
       contents: write  # Needed for git push
       id-token: write  # Needed for npm publish
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.BOT_SSH_KEY}}

--- a/.github/workflows/sync-apis.yml
+++ b/.github/workflows/sync-apis.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ secrets.BOT_GH_TOKEN }}
     - uses: './.github/actions/setup-environment'
@@ -28,7 +28,7 @@ jobs:
     - name: Build packages
       run: npm run build:no-cache
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
       with:
         token: ${{ secrets.BOT_GH_TOKEN }}
         title: 'chore(nightly-sync): API sync and client generation'


### PR DESCRIPTION
### Description
  <!-- Summary of proposed changes: what and why. -->

  [RHCLOUD-48335](https://issues.redhat.com/browse/RHCLOUD-48335)

  GitHub Actions CI security hardening to prevent supply chain attacks and reduce permission blast radius:

  1. **SHA-pinned all external actions** — Replaced version tags (`@v4`, `@v5`, `@v7`) with commit SHAs to prevent compromised action tags from injecting malicious code
  2. **Scoped `id-token: write` permission** — Removed from top-level, kept only in release job where needed for npm publish
  3. **Added environment protection** — Release job now uses `environment: npm-publish` for additional deployment gate
  4. **Did not add Dependabot** - going to see if mint maker handles it first

  ---

  Anything reviewers should know?

  <!-- Trade-offs, performance considerations, pre/post merge actions required. -->

  ⚠️  REQUIRED BEFORE MERGE: Repo admin must create GitHub Environment:

  1. Settings > Environments > New environment: npm-publish
  2. Deployment branches: main only

  Without this, release job will fail with "environment not found" error.

  SHA pinning: Actions include version comment for humans (e.g., # v4.2.2). Dependabot will update both SHA and comment on new releases.

  ---
  Checklist

  - [x] Tests: new/updated tests cover the change
  - [x] API: spec updated if endpoints changed (or N/A)
  - [x] Migrations: backwards compatible if schema changed (or N/A)
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against secure coding checklist (or N/A)

  AI disclosure

  <!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->

  Implemented by: Claude Code

[RHCLOUD-48335]: https://redhat.atlassian.net/browse/RHCLOUD-48335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ