### PR TITLE
feat(rbac)!: regenerate v2 client from latest openapi spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10295,7 +10295,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10312,7 +10311,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10329,7 +10327,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -10346,7 +10343,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10363,7 +10359,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10380,7 +10375,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10397,7 +10391,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10414,7 +10407,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10431,7 +10423,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10448,7 +10439,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -10469,7 +10459,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"

--- a/packages/rbac/src/types/index.ts
+++ b/packages/rbac/src/types/index.ts
@@ -203,12 +203,6 @@ export interface CrossAccountRequest {
      * @type {string}
      * @memberof CrossAccountRequest
      */
-    'target_account'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequest
-     */
     'target_org'?: string;
     /**
      *
@@ -247,12 +241,6 @@ export interface CrossAccountRequestByAccount {
      * @memberof CrossAccountRequestByAccount
      */
     'request_id'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestByAccount
-     */
-    'target_account'?: string;
     /**
      *
      * @type {string}
@@ -325,12 +313,6 @@ export interface CrossAccountRequestByUserId {
      * @type {string}
      * @memberof CrossAccountRequestByUserId
      */
-    'target_account'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestByUserId
-     */
     'target_org'?: string;
     /**
      *
@@ -387,12 +369,6 @@ export interface CrossAccountRequestDetailByAccount {
      * @memberof CrossAccountRequestDetailByAccount
      */
     'request_id'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestDetailByAccount
-     */
-    'target_account'?: string;
     /**
      *
      * @type {string}
@@ -465,12 +441,6 @@ export interface CrossAccountRequestDetailByUseId {
      * @type {string}
      * @memberof CrossAccountRequestDetailByUseId
      */
-    'target_account'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestDetailByUseId
-     */
     'target_org'?: string;
     /**
      *
@@ -520,12 +490,6 @@ export interface CrossAccountRequestIn {
      * @type {string}
      * @memberof CrossAccountRequestIn
      */
-    'target_account'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestIn
-     */
     'target_org': string;
     /**
      *
@@ -558,12 +522,6 @@ export interface CrossAccountRequestOut {
      * @memberof CrossAccountRequestOut
      */
     'request_id'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestOut
-     */
-    'target_account'?: string;
     /**
      *
      * @type {string}
@@ -717,12 +675,6 @@ export interface CrossAccountRequestWithRoles {
      * @memberof CrossAccountRequestWithRoles
      */
     'request_id'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof CrossAccountRequestWithRoles
-     */
-    'target_account'?: string;
     /**
      *
      * @type {string}

--- a/packages/rbac/src/v2/RoleBindingsBatchCreate/index.ts
+++ b/packages/rbac/src/v2/RoleBindingsBatchCreate/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, RoleBindingsBatchCreateRoleBindingsRequest, RoleBindingsBatchCreateRoleBindingsResponse, RoleBindingsList401Response, RoleBindingsList500Response } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, RoleBindingsBatchCreateRoleBindingsRequest, RoleBindingsBatchCreateRoleBindingsResponse } from '../types';
 
 
 export type RoleBindingsBatchCreateParams = {

--- a/packages/rbac/src/v2/RoleBindingsList/index.ts
+++ b/packages/rbac/src/v2/RoleBindingsList/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ExcludeSources, ProblemsProblem403, RoleBindingsBindingSubjectType, RoleBindingsGrantedSubjectFilterType, RoleBindingsList200Response, RoleBindingsList401Response, RoleBindingsList500Response } from '../types';
+import type { ExcludeSources, ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, RoleBindingsBindingSubjectType, RoleBindingsGrantedSubjectFilterType, RoleBindingsList200Response } from '../types';
 
 
 export type RoleBindingsListParams = {

--- a/packages/rbac/src/v2/RoleBindingsListBySubject/index.ts
+++ b/packages/rbac/src/v2/RoleBindingsListBySubject/index.ts
@@ -8,22 +8,10 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ExcludeSources, ProblemsProblem403, ResourceType, RoleBindingsBindingSubjectType, RoleBindingsList401Response, RoleBindingsList500Response, RoleBindingsListBySubject200Response } from '../types';
+import type { ExcludeSources, ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, ResourceType, RoleBindingsBindingSubjectType, RoleBindingsListBySubject200Response } from '../types';
 
 
 export type RoleBindingsListBySubjectParams = {
-  /**
-  * Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}).
-  * @type { string }
-  * @memberof RoleBindingsListBySubjectApi
-  */
-  resourceId: string,
-  /**
-  * Filter by resource type
-  * @type { ResourceType }
-  * @memberof RoleBindingsListBySubjectApi
-  */
-  resourceType: ResourceType,
   /**
   *
   * @type { number }
@@ -36,6 +24,24 @@ export type RoleBindingsListBySubjectParams = {
   * @memberof RoleBindingsListBySubjectApi
   */
   cursor?: string,
+  /**
+  * Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Required unless resource.tenant.org_id is provided.
+  * @type { string }
+  * @memberof RoleBindingsListBySubjectApi
+  */
+  resourceId?: string,
+  /**
+  * Filter by resource type. Required unless resource.tenant.org_id is provided.
+  * @type { ResourceType }
+  * @memberof RoleBindingsListBySubjectApi
+  */
+  resourceType?: ResourceType,
+  /**
+  * Org ID of the tenant resource to filter by. Cannot be combined with resource_id. When provided, resource_type is implicitly \'tenant\'.
+  * @type { string }
+  * @memberof RoleBindingsListBySubjectApi
+  */
+  resourceTenantOrgId?: string,
   /**
   * Filter by binding subject kind: group or user (principal UUID). There is no granted_subject.* on this endpoint.
   * @type { RoleBindingsBindingSubjectType }
@@ -74,7 +80,7 @@ export type RoleBindingsListBySubjectReturnType = RoleBindingsListBySubject200Re
 const isRoleBindingsListBySubjectObjectParams = (params: [RoleBindingsListBySubjectParams] | unknown[]): params is [RoleBindingsListBySubjectParams] => {
   const l = params.length === 1
   if(l && typeof params[0] === 'object' && !Array.isArray(params[0])) {
-    return true && Object.prototype.hasOwnProperty.call(params[0], 'resourceId') && Object.prototype.hasOwnProperty.call(params[0], 'resourceType')
+    return true
   }
   return false
 }
@@ -85,9 +91,9 @@ const isRoleBindingsListBySubjectObjectParams = (params: [RoleBindingsListBySubj
 * @param {*} [options] Override http request option.
 * @throws {RequiredError}
 */
-export const roleBindingsListBySubjectParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RoleBindingsListBySubjectParams] | [string, ResourceType, number, string, RoleBindingsBindingSubjectType, string, ExcludeSources, string, string, AxiosRequestConfig])) => {
-    const params = isRoleBindingsListBySubjectObjectParams(config) ? config[0] : ['resourceId', 'resourceType', 'limit', 'cursor', 'subjectType', 'subjectId', 'excludeSources', 'fields', 'orderBy', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RoleBindingsListBySubjectParams;
-    const { resourceId, resourceType, limit, cursor, subjectType, subjectId, excludeSources, fields, orderBy, options = {} } = params;
+export const roleBindingsListBySubjectParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RoleBindingsListBySubjectParams] | [number, string, string, ResourceType, string, RoleBindingsBindingSubjectType, string, ExcludeSources, string, string, AxiosRequestConfig])) => {
+    const params = isRoleBindingsListBySubjectObjectParams(config) ? config[0] : ['limit', 'cursor', 'resourceId', 'resourceType', 'resourceTenantOrgId', 'subjectType', 'subjectId', 'excludeSources', 'fields', 'orderBy', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RoleBindingsListBySubjectParams;
+    const { limit, cursor, resourceId, resourceType, resourceTenantOrgId, subjectType, subjectId, excludeSources, fields, orderBy, options = {} } = params;
     const localVarPath = `/role-bindings/by-subject/`;
     // use dummy base URL string because the URL constructor only accepts absolute URLs.
     const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -109,6 +115,10 @@ export const roleBindingsListBySubjectParamCreator = async (sendRequest: BaseAPI
 
     if (resourceType !== undefined) {
         localVarQueryParameter['resource_type'] = resourceType;
+    }
+
+    if (resourceTenantOrgId !== undefined) {
+        localVarQueryParameter['resource.tenant.org_id'] = resourceTenantOrgId;
     }
 
     if (subjectType !== undefined) {

--- a/packages/rbac/src/v2/RoleBindingsUpdate/index.ts
+++ b/packages/rbac/src/v2/RoleBindingsUpdate/index.ts
@@ -8,22 +8,10 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, ProblemsProblem404, ResourceType, RoleBindingsBindingSubjectType, RoleBindingsList401Response, RoleBindingsList500Response, RoleBindingsRoleBindingBySubject, RoleBindingsUpdateRoleBindingsRequest } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, ResourceType, RoleBindingsBindingSubjectType, RoleBindingsRoleBindingBySubject, RoleBindingsUpdateRoleBindingsRequest } from '../types';
 
 
 export type RoleBindingsUpdateParams = {
-  /**
-  * Identify the resource ID for the set of role bindings to replace. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}).
-  * @type { string }
-  * @memberof RoleBindingsUpdateApi
-  */
-  resourceId: string,
-  /**
-  * Identify the resource type for the set of role bindings to replace
-  * @type { ResourceType }
-  * @memberof RoleBindingsUpdateApi
-  */
-  resourceType: ResourceType,
   /**
   * Identify the subject ID for the set of role bindings to replace
   * @type { string }
@@ -43,6 +31,24 @@ export type RoleBindingsUpdateParams = {
   */
   roleBindingsUpdateRoleBindingsRequest: RoleBindingsUpdateRoleBindingsRequest,
   /**
+  * Identify the resource ID for the set of role bindings to replace. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Required unless resource.tenant.org_id is provided.
+  * @type { string }
+  * @memberof RoleBindingsUpdateApi
+  */
+  resourceId?: string,
+  /**
+  * Identify the resource type for the set of role bindings to replace. Required unless resource.tenant.org_id is provided.
+  * @type { ResourceType }
+  * @memberof RoleBindingsUpdateApi
+  */
+  resourceType?: ResourceType,
+  /**
+  * Org ID of the tenant resource. Cannot be combined with resource_id. When provided, resource_type is implicitly \'tenant\'.
+  * @type { string }
+  * @memberof RoleBindingsUpdateApi
+  */
+  resourceTenantOrgId?: string,
+  /**
   *
   * @type { string }
   * @memberof RoleBindingsUpdateApi
@@ -56,7 +62,7 @@ export type RoleBindingsUpdateReturnType = RoleBindingsRoleBindingBySubject;
 const isRoleBindingsUpdateObjectParams = (params: [RoleBindingsUpdateParams] | unknown[]): params is [RoleBindingsUpdateParams] => {
   const l = params.length === 1
   if(l && typeof params[0] === 'object' && !Array.isArray(params[0])) {
-    return true && Object.prototype.hasOwnProperty.call(params[0], 'resourceId') && Object.prototype.hasOwnProperty.call(params[0], 'resourceType') && Object.prototype.hasOwnProperty.call(params[0], 'subjectId') && Object.prototype.hasOwnProperty.call(params[0], 'subjectType') && Object.prototype.hasOwnProperty.call(params[0], 'roleBindingsUpdateRoleBindingsRequest')
+    return true && Object.prototype.hasOwnProperty.call(params[0], 'subjectId') && Object.prototype.hasOwnProperty.call(params[0], 'subjectType') && Object.prototype.hasOwnProperty.call(params[0], 'roleBindingsUpdateRoleBindingsRequest')
   }
   return false
 }
@@ -67,9 +73,9 @@ const isRoleBindingsUpdateObjectParams = (params: [RoleBindingsUpdateParams] | u
 * @param {*} [options] Override http request option.
 * @throws {RequiredError}
 */
-export const roleBindingsUpdateParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RoleBindingsUpdateParams] | [string, ResourceType, string, RoleBindingsBindingSubjectType, RoleBindingsUpdateRoleBindingsRequest, string, AxiosRequestConfig])) => {
-    const params = isRoleBindingsUpdateObjectParams(config) ? config[0] : ['resourceId', 'resourceType', 'subjectId', 'subjectType', 'roleBindingsUpdateRoleBindingsRequest', 'fields', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RoleBindingsUpdateParams;
-    const { resourceId, resourceType, subjectId, subjectType, roleBindingsUpdateRoleBindingsRequest, fields, options = {} } = params;
+export const roleBindingsUpdateParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RoleBindingsUpdateParams] | [string, RoleBindingsBindingSubjectType, RoleBindingsUpdateRoleBindingsRequest, string, ResourceType, string, string, AxiosRequestConfig])) => {
+    const params = isRoleBindingsUpdateObjectParams(config) ? config[0] : ['subjectId', 'subjectType', 'roleBindingsUpdateRoleBindingsRequest', 'resourceId', 'resourceType', 'resourceTenantOrgId', 'fields', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RoleBindingsUpdateParams;
+    const { subjectId, subjectType, roleBindingsUpdateRoleBindingsRequest, resourceId, resourceType, resourceTenantOrgId, fields, options = {} } = params;
     const localVarPath = `/role-bindings/by-subject/`;
     // use dummy base URL string because the URL constructor only accepts absolute URLs.
     const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -83,6 +89,10 @@ export const roleBindingsUpdateParamCreator = async (sendRequest: BaseAPI["sendR
 
     if (resourceType !== undefined) {
         localVarQueryParameter['resource_type'] = resourceType;
+    }
+
+    if (resourceTenantOrgId !== undefined) {
+        localVarQueryParameter['resource.tenant.org_id'] = resourceTenantOrgId;
     }
 
     if (subjectId !== undefined) {

--- a/packages/rbac/src/v2/RolesBatchDelete/index.ts
+++ b/packages/rbac/src/v2/RolesBatchDelete/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, ProblemsProblem404, RoleBindingsList401Response, RoleBindingsList500Response, RolesBatchDeleteRolesRequest } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, RolesBatchDeleteRolesRequest } from '../types';
 
 
 export type RolesBatchDeleteParams = {

--- a/packages/rbac/src/v2/RolesCreate/index.ts
+++ b/packages/rbac/src/v2/RolesCreate/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, Role, RoleBindingsList401Response, RoleBindingsList500Response, RolesCreateOrUpdateRoleRequest } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, Role, RolesCreateOrUpdateRoleRequest } from '../types';
 
 
 export type RolesCreateParams = {

--- a/packages/rbac/src/v2/RolesList/index.ts
+++ b/packages/rbac/src/v2/RolesList/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, RoleBindingsList401Response, RoleBindingsList500Response, RolesList200Response } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, RolesList200Response } from '../types';
 
 
 export type RolesListParams = {
@@ -25,7 +25,7 @@ export type RolesListParams = {
   */
   cursor?: string,
   /**
-  * Filter by role name. Exact match by default; use * as a wildcard for partial matching (e.g. foo*).
+  * Filter by role name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).
   * @type { string }
   * @memberof RolesListApi
   */
@@ -37,17 +37,29 @@ export type RolesListParams = {
   */
   resourceType?: string,
   /**
-  * Filter by resource ID. Requires resource_type to be specified.
+  * Filter by resource ID. For workspace: UUID. For tenant: tenant resource ID (format: {domain}/{org_id}). Requires resource_type unless resource.tenant.org_id is provided.
   * @type { string }
   * @memberof RolesListApi
   */
   resourceId?: string,
+  /**
+  * Org ID of the tenant resource to filter by. Cannot be combined with resource_id. When provided, resource_type is implicitly \'tenant\'.
+  * @type { string }
+  * @memberof RolesListApi
+  */
+  resourceTenantOrgId?: string,
   /**
   * Control which fields are included in the response to optimize payload size.
   * @type { string }
   * @memberof RolesListApi
   */
   fields?: string,
+  /**
+  * Filter by permission string(s). Comma-separated exact match (e.g. \'inventory:hosts:read\' or \'inventory:hosts:read,rbac:workspace:write\').
+  * @type { string }
+  * @memberof RolesListApi
+  */
+  permission?: string,
   /**
   * Sort by specified field(s), prefix with \'-\' for descending order. Allowed fields: name, last_modified.
   * @type { string }
@@ -73,9 +85,9 @@ const isRolesListObjectParams = (params: [RolesListParams] | unknown[]): params 
 * @param {*} [options] Override http request option.
 * @throws {RequiredError}
 */
-export const rolesListParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RolesListParams] | [number, string, string, string, string, string, string, AxiosRequestConfig])) => {
-    const params = isRolesListObjectParams(config) ? config[0] : ['limit', 'cursor', 'name', 'resourceType', 'resourceId', 'fields', 'orderBy', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RolesListParams;
-    const { limit, cursor, name, resourceType, resourceId, fields, orderBy, options = {} } = params;
+export const rolesListParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([RolesListParams] | [number, string, string, string, string, string, string, string, string, AxiosRequestConfig])) => {
+    const params = isRolesListObjectParams(config) ? config[0] : ['limit', 'cursor', 'name', 'resourceType', 'resourceId', 'resourceTenantOrgId', 'fields', 'permission', 'orderBy', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as RolesListParams;
+    const { limit, cursor, name, resourceType, resourceId, resourceTenantOrgId, fields, permission, orderBy, options = {} } = params;
     const localVarPath = `/roles/`;
     // use dummy base URL string because the URL constructor only accepts absolute URLs.
     const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -103,8 +115,16 @@ export const rolesListParamCreator = async (sendRequest: BaseAPI["sendRequest"],
         localVarQueryParameter['resource_id'] = resourceId;
     }
 
+    if (resourceTenantOrgId !== undefined) {
+        localVarQueryParameter['resource.tenant.org_id'] = resourceTenantOrgId;
+    }
+
     if (fields !== undefined) {
         localVarQueryParameter['fields'] = fields;
+    }
+
+    if (permission !== undefined) {
+        localVarQueryParameter['permission'] = permission;
     }
 
     if (orderBy !== undefined) {

--- a/packages/rbac/src/v2/RolesRead/index.ts
+++ b/packages/rbac/src/v2/RolesRead/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, ProblemsProblem404, Role, RoleBindingsList401Response, RoleBindingsList500Response } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, Role } from '../types';
 
 
 export type RolesReadParams = {

--- a/packages/rbac/src/v2/RolesUpdate/index.ts
+++ b/packages/rbac/src/v2/RolesUpdate/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, ProblemsProblem404, Role, RoleBindingsList401Response, RoleBindingsList500Response, RolesCreateOrUpdateRoleRequest } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, Role, RolesCreateOrUpdateRoleRequest } from '../types';
 
 
 export type RolesUpdateParams = {

--- a/packages/rbac/src/v2/WorkspacesCreate/index.ts
+++ b/packages/rbac/src/v2/WorkspacesCreate/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesCreateWorkspaceRequest, WorkspacesCreateWorkspaceResponse } from '../types';
+import type { ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, WorkspacesCreate400Response, WorkspacesCreateWorkspaceRequest, WorkspacesCreateWorkspaceResponse } from '../types';
 
 
 export type WorkspacesCreateParams = {

--- a/packages/rbac/src/v2/WorkspacesDelete/index.ts
+++ b/packages/rbac/src/v2/WorkspacesDelete/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, ProblemsWorkspaceProblem400WorkspaceNotEmpty, RoleBindingsList401Response, RoleBindingsList500Response } from '../types';
+import type { ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, WorkspacesDelete400Response } from '../types';
 
 
 export type WorkspacesDeleteParams = {

--- a/packages/rbac/src/v2/WorkspacesList/index.ts
+++ b/packages/rbac/src/v2/WorkspacesList/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesWorkspaceListResponse, WorkspacesWorkspaceTypesQueryParam } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, WorkspacesWorkspaceListResponse } from '../types';
 
 
 export type WorkspacesListParams = {
@@ -25,13 +25,13 @@ export type WorkspacesListParams = {
   */
   offset?: number,
   /**
-  * Defaults to all when param is not supplied.
-  * @type { WorkspacesWorkspaceTypesQueryParam }
+  * Filter by workspace type. Supports comma-separated values (e.g. type=standard,ungrouped-hosts). Defaults to all when not supplied. Case-insensitive.
+  * @type { string }
   * @memberof WorkspacesListApi
   */
-  type?: WorkspacesWorkspaceTypesQueryParam,
+  type?: string,
   /**
-  * Case sensitive exact match of workspace by name.
+  * Filter by workspace name. Case-insensitive substring match by default; use * for glob patterns (e.g. foo*).
   * @type { string }
   * @memberof WorkspacesListApi
   */
@@ -54,6 +54,12 @@ export type WorkspacesListParams = {
   * @memberof WorkspacesListApi
   */
   orderBy?: string,
+  /**
+  * When true, list responses include ancestor workspaces for tree navigation and fallback workspaces (root, default, ungrouped) when the user has no explicit access. When false (default), only workspaces with explicit Inventory permission are returned.
+  * @type { boolean }
+  * @memberof WorkspacesListApi
+  */
+  withAncestry?: boolean,
   options?: AxiosRequestConfig
 }
 
@@ -73,9 +79,9 @@ const isWorkspacesListObjectParams = (params: [WorkspacesListParams] | unknown[]
 * @param {*} [options] Override http request option.
 * @throws {RequiredError}
 */
-export const workspacesListParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([WorkspacesListParams] | [number, number, WorkspacesWorkspaceTypesQueryParam, string, string, Array<string>, string, AxiosRequestConfig])) => {
-    const params = isWorkspacesListObjectParams(config) ? config[0] : ['limit', 'offset', 'type', 'name', 'parentId', 'ids', 'orderBy', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as WorkspacesListParams;
-    const { limit, offset, type, name, parentId, ids, orderBy, options = {} } = params;
+export const workspacesListParamCreator = async (sendRequest: BaseAPI["sendRequest"], ...config: ([WorkspacesListParams] | [number, number, string, string, string, Array<string>, string, boolean, AxiosRequestConfig])) => {
+    const params = isWorkspacesListObjectParams(config) ? config[0] : ['limit', 'offset', 'type', 'name', 'parentId', 'ids', 'orderBy', 'withAncestry', 'options'].reduce((acc, curr, index) => ({ ...acc, [curr]: config[index] }), {}) as WorkspacesListParams;
+    const { limit, offset, type, name, parentId, ids, orderBy, withAncestry, options = {} } = params;
     const localVarPath = `/workspaces/`;
     // use dummy base URL string because the URL constructor only accepts absolute URLs.
     const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -109,6 +115,10 @@ export const workspacesListParamCreator = async (sendRequest: BaseAPI["sendReque
 
     if (orderBy !== undefined) {
         localVarQueryParameter['order_by'] = orderBy;
+    }
+
+    if (withAncestry !== undefined) {
+        localVarQueryParameter['with_ancestry'] = withAncestry;
     }
 
 

--- a/packages/rbac/src/v2/WorkspacesMove/index.ts
+++ b/packages/rbac/src/v2/WorkspacesMove/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem400, ProblemsProblem403, ProblemsProblem404, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesMoveWorkspaceRequest, WorkspacesMoveWorkspaceResponse } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, WorkspacesMoveWorkspaceRequest, WorkspacesMoveWorkspaceResponse } from '../types';
 
 
 export type WorkspacesMoveParams = {

--- a/packages/rbac/src/v2/WorkspacesPatch/index.ts
+++ b/packages/rbac/src/v2/WorkspacesPatch/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesPatchWorkspaceRequest, WorkspacesPatchWorkspaceResponse, WorkspacesUpdate400Response } from '../types';
+import type { ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, WorkspacesCreate400Response, WorkspacesPatchWorkspaceRequest, WorkspacesPatchWorkspaceResponse } from '../types';
 
 
 export type WorkspacesPatchParams = {

--- a/packages/rbac/src/v2/WorkspacesRead/index.ts
+++ b/packages/rbac/src/v2/WorkspacesRead/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, ProblemsProblem404, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesRead200Response } from '../types';
+import type { ProblemsProblem400, ProblemsProblem401, ProblemsProblem403, ProblemsProblem404, ProblemsProblem500, WorkspacesRead200Response } from '../types';
 
 
 export type WorkspacesReadParams = {

--- a/packages/rbac/src/v2/WorkspacesUpdate/index.ts
+++ b/packages/rbac/src/v2/WorkspacesUpdate/index.ts
@@ -8,7 +8,7 @@ import { BaseAPI } from '@redhat-cloud-services/javascript-clients-shared/dist/b
 import { Configuration } from '@redhat-cloud-services/javascript-clients-shared/dist/configuration';
 
 // @ts-ignore
-import type { ProblemsProblem403, RoleBindingsList401Response, RoleBindingsList500Response, WorkspacesUpdate400Response, WorkspacesUpdateWorkspaceRequest, WorkspacesUpdateWorkspaceResponse } from '../types';
+import type { ProblemsProblem401, ProblemsProblem403, ProblemsProblem500, WorkspacesCreate400Response, WorkspacesUpdateWorkspaceRequest, WorkspacesUpdateWorkspaceResponse } from '../types';
 
 
 export type WorkspacesUpdateParams = {

--- a/packages/rbac/src/v2/types/index.ts
+++ b/packages/rbac/src/v2/types/index.ts
@@ -137,6 +137,12 @@ export interface ProblemsProblem400 {
      * @type {string}
      * @memberof ProblemsProblem400
      */
+    'type': ProblemsProblem400TypeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem400
+     */
     'title': ProblemsProblem400TitleEnum;
     /**
      *
@@ -144,12 +150,6 @@ export interface ProblemsProblem400 {
      * @memberof ProblemsProblem400
      */
     'detail': string;
-    /**
-     *
-     * @type {ProblemsProblemType}
-     * @memberof ProblemsProblem400
-     */
-    'type'?: ProblemsProblemType;
     /**
      *
      * @type {number}
@@ -164,6 +164,11 @@ export interface ProblemsProblem400 {
     'instance'?: string;
 }
 
+export const ProblemsProblem400TypeEnum = {
+    HttpProjectKesselOrgProblemsInvalidRequest: 'http://project-kessel.org/problems/invalid-request'
+} as const;
+
+export type ProblemsProblem400TypeEnum = typeof ProblemsProblem400TypeEnum[keyof typeof ProblemsProblem400TypeEnum];
 export const ProblemsProblem400TitleEnum = {
     TheRequestPayloadContainsInvalidSyntax: 'The request payload contains invalid syntax.'
 } as const;
@@ -174,6 +179,114 @@ export const ProblemsProblem400StatusEnum = {
 } as const;
 
 export type ProblemsProblem400StatusEnum = typeof ProblemsProblem400StatusEnum[keyof typeof ProblemsProblem400StatusEnum];
+
+/**
+ *
+ * @export
+ * @interface ProblemsProblem400AlreadyExists
+ */
+export interface ProblemsProblem400AlreadyExists {
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem400AlreadyExists
+     */
+    'type': ProblemsProblem400AlreadyExistsTypeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem400AlreadyExists
+     */
+    'title': ProblemsProblem400AlreadyExistsTitleEnum;
+    /**
+     *
+     * @type {number}
+     * @memberof ProblemsProblem400AlreadyExists
+     */
+    'status'?: ProblemsProblem400AlreadyExistsStatusEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem400AlreadyExists
+     */
+    'detail'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem400AlreadyExists
+     */
+    'instance'?: string;
+}
+
+export const ProblemsProblem400AlreadyExistsTypeEnum = {
+    HttpProjectKesselOrgProblemsAlreadyExists: 'http://project-kessel.org/problems/already-exists'
+} as const;
+
+export type ProblemsProblem400AlreadyExistsTypeEnum = typeof ProblemsProblem400AlreadyExistsTypeEnum[keyof typeof ProblemsProblem400AlreadyExistsTypeEnum];
+export const ProblemsProblem400AlreadyExistsTitleEnum = {
+    TheResourceAlreadyExists: 'The resource already exists.'
+} as const;
+
+export type ProblemsProblem400AlreadyExistsTitleEnum = typeof ProblemsProblem400AlreadyExistsTitleEnum[keyof typeof ProblemsProblem400AlreadyExistsTitleEnum];
+export const ProblemsProblem400AlreadyExistsStatusEnum = {
+    NUMBER_400: 400
+} as const;
+
+export type ProblemsProblem400AlreadyExistsStatusEnum = typeof ProblemsProblem400AlreadyExistsStatusEnum[keyof typeof ProblemsProblem400AlreadyExistsStatusEnum];
+
+/**
+ *
+ * @export
+ * @interface ProblemsProblem401
+ */
+export interface ProblemsProblem401 {
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem401
+     */
+    'type': ProblemsProblem401TypeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem401
+     */
+    'title': ProblemsProblem401TitleEnum;
+    /**
+     *
+     * @type {number}
+     * @memberof ProblemsProblem401
+     */
+    'status'?: ProblemsProblem401StatusEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem401
+     */
+    'detail'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem401
+     */
+    'instance'?: string;
+}
+
+export const ProblemsProblem401TypeEnum = {
+    HttpProjectKesselOrgProblemsUnauthenticated: 'http://project-kessel.org/problems/unauthenticated'
+} as const;
+
+export type ProblemsProblem401TypeEnum = typeof ProblemsProblem401TypeEnum[keyof typeof ProblemsProblem401TypeEnum];
+export const ProblemsProblem401TitleEnum = {
+    AuthenticationCredentialsWereNotProvidedOrAreInvalid: 'Authentication credentials were not provided or are invalid.'
+} as const;
+
+export type ProblemsProblem401TitleEnum = typeof ProblemsProblem401TitleEnum[keyof typeof ProblemsProblem401TitleEnum];
+export const ProblemsProblem401StatusEnum = {
+    NUMBER_401: 401
+} as const;
+
+export type ProblemsProblem401StatusEnum = typeof ProblemsProblem401StatusEnum[keyof typeof ProblemsProblem401StatusEnum];
 
 /**
  *
@@ -240,6 +353,12 @@ export interface ProblemsProblem404 {
      * @type {string}
      * @memberof ProblemsProblem404
      */
+    'type': ProblemsProblem404TypeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem404
+     */
     'title': ProblemsProblem404TitleEnum;
     /**
      *
@@ -247,12 +366,6 @@ export interface ProblemsProblem404 {
      * @memberof ProblemsProblem404
      */
     'detail': string;
-    /**
-     *
-     * @type {ProblemsProblemType}
-     * @memberof ProblemsProblem404
-     */
-    'type'?: ProblemsProblemType;
     /**
      *
      * @type {number}
@@ -267,6 +380,11 @@ export interface ProblemsProblem404 {
     'instance'?: string;
 }
 
+export const ProblemsProblem404TypeEnum = {
+    HttpProjectKesselOrgProblemsNotFound: 'http://project-kessel.org/problems/not-found'
+} as const;
+
+export type ProblemsProblem404TypeEnum = typeof ProblemsProblem404TypeEnum[keyof typeof ProblemsProblem404TypeEnum];
 export const ProblemsProblem404TitleEnum = {
     ResourceWasNotFound: 'Resource was not found'
 } as const;
@@ -281,11 +399,71 @@ export type ProblemsProblem404StatusEnum = typeof ProblemsProblem404StatusEnum[k
 /**
  *
  * @export
+ * @interface ProblemsProblem500
+ */
+export interface ProblemsProblem500 {
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem500
+     */
+    'type': ProblemsProblem500TypeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem500
+     */
+    'title': ProblemsProblem500TitleEnum;
+    /**
+     *
+     * @type {number}
+     * @memberof ProblemsProblem500
+     */
+    'status'?: ProblemsProblem500StatusEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem500
+     */
+    'detail'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof ProblemsProblem500
+     */
+    'instance'?: string;
+}
+
+export const ProblemsProblem500TypeEnum = {
+    HttpProjectKesselOrgProblemsInternalError: 'http://project-kessel.org/problems/internal-error'
+} as const;
+
+export type ProblemsProblem500TypeEnum = typeof ProblemsProblem500TypeEnum[keyof typeof ProblemsProblem500TypeEnum];
+export const ProblemsProblem500TitleEnum = {
+    UnexpectedErrorOccurred: 'Unexpected error occurred.'
+} as const;
+
+export type ProblemsProblem500TitleEnum = typeof ProblemsProblem500TitleEnum[keyof typeof ProblemsProblem500TitleEnum];
+export const ProblemsProblem500StatusEnum = {
+    NUMBER_500: 500
+} as const;
+
+export type ProblemsProblem500StatusEnum = typeof ProblemsProblem500StatusEnum[keyof typeof ProblemsProblem500StatusEnum];
+
+/**
+ *
+ * @export
  * @enum {string}
  */
 
 export const ProblemsProblemType = {
-    HttpProjectKesselOrgProblemsInsufficientPermission: 'http://project-kessel.org/problems/insufficient-permission'
+    InsufficientPermission: 'http://project-kessel.org/problems/insufficient-permission',
+    Unauthenticated: 'http://project-kessel.org/problems/unauthenticated',
+    NotFound: 'http://project-kessel.org/problems/not-found',
+    InternalError: 'http://project-kessel.org/problems/internal-error',
+    InvalidRequest: 'http://project-kessel.org/problems/invalid-request',
+    AlreadyExists: 'http://project-kessel.org/problems/already-exists',
+    WorkspaceNotEmpty: 'http://project-kessel.org/problems/workspace-not-empty'
 } as const;
 
 export type ProblemsProblemType = typeof ProblemsProblemType[keyof typeof ProblemsProblemType];
@@ -302,13 +480,13 @@ export interface ProblemsWorkspaceProblem400WorkspaceNotEmpty {
      * @type {string}
      * @memberof ProblemsWorkspaceProblem400WorkspaceNotEmpty
      */
-    'title': ProblemsWorkspaceProblem400WorkspaceNotEmptyTitleEnum;
+    'type': ProblemsWorkspaceProblem400WorkspaceNotEmptyTypeEnum;
     /**
      *
-     * @type {ProblemsProblemType}
+     * @type {string}
      * @memberof ProblemsWorkspaceProblem400WorkspaceNotEmpty
      */
-    'type'?: ProblemsProblemType;
+    'title': ProblemsWorkspaceProblem400WorkspaceNotEmptyTitleEnum;
     /**
      *
      * @type {number}
@@ -329,6 +507,11 @@ export interface ProblemsWorkspaceProblem400WorkspaceNotEmpty {
     'instance'?: string;
 }
 
+export const ProblemsWorkspaceProblem400WorkspaceNotEmptyTypeEnum = {
+    HttpProjectKesselOrgProblemsWorkspaceNotEmpty: 'http://project-kessel.org/problems/workspace-not-empty'
+} as const;
+
+export type ProblemsWorkspaceProblem400WorkspaceNotEmptyTypeEnum = typeof ProblemsWorkspaceProblem400WorkspaceNotEmptyTypeEnum[keyof typeof ProblemsWorkspaceProblem400WorkspaceNotEmptyTypeEnum];
 export const ProblemsWorkspaceProblem400WorkspaceNotEmptyTitleEnum = {
     UnableToDeleteDueToWorkspaceDependencies: 'Unable to delete due to workspace dependencies'
 } as const;
@@ -494,7 +677,7 @@ export interface RoleBindingsCreateRoleBindingsRequest {
  */
 export interface RoleBindingsCreateRoleBindingsRequestResource {
     /**
-     *
+     * Identifier of the resource
      * @type {string}
      * @memberof RoleBindingsCreateRoleBindingsRequestResource
      */
@@ -634,94 +817,6 @@ export interface RoleBindingsList200Response {
 /**
  *
  * @export
- * @interface RoleBindingsList401Response
- */
-export interface RoleBindingsList401Response {
-    /**
-     *
-     * @type {ProblemsProblemType}
-     * @memberof RoleBindingsList401Response
-     */
-    'type'?: ProblemsProblemType;
-    /**
-     *
-     * @type {number}
-     * @memberof RoleBindingsList401Response
-     */
-    'status'?: RoleBindingsList401ResponseStatusEnum;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList401Response
-     */
-    'title'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList401Response
-     */
-    'detail'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList401Response
-     */
-    'instance'?: string;
-}
-
-export const RoleBindingsList401ResponseStatusEnum = {
-    NUMBER_401: 401
-} as const;
-
-export type RoleBindingsList401ResponseStatusEnum = typeof RoleBindingsList401ResponseStatusEnum[keyof typeof RoleBindingsList401ResponseStatusEnum];
-
-/**
- *
- * @export
- * @interface RoleBindingsList500Response
- */
-export interface RoleBindingsList500Response {
-    /**
-     *
-     * @type {ProblemsProblemType}
-     * @memberof RoleBindingsList500Response
-     */
-    'type'?: ProblemsProblemType;
-    /**
-     *
-     * @type {number}
-     * @memberof RoleBindingsList500Response
-     */
-    'status'?: RoleBindingsList500ResponseStatusEnum;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList500Response
-     */
-    'title'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList500Response
-     */
-    'detail'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof RoleBindingsList500Response
-     */
-    'instance'?: string;
-}
-
-export const RoleBindingsList500ResponseStatusEnum = {
-    NUMBER_500: 500
-} as const;
-
-export type RoleBindingsList500ResponseStatusEnum = typeof RoleBindingsList500ResponseStatusEnum[keyof typeof RoleBindingsList500ResponseStatusEnum];
-
-/**
- *
- * @export
  * @interface RoleBindingsListBySubject200Response
  */
 export interface RoleBindingsListBySubject200Response {
@@ -751,7 +846,7 @@ export interface RoleBindingsListBySubject200Response {
  */
 export interface RoleBindingsResource {
     /**
-     *
+     * Resource identifier
      * @type {string}
      * @memberof RoleBindingsResource
      */
@@ -1057,6 +1152,50 @@ export interface WorkspacesBasicWorkspace {
 /**
  *
  * @export
+ * @interface WorkspacesCreate400Response
+ */
+export interface WorkspacesCreate400Response {
+    /**
+     *
+     * @type {ProblemsProblemType}
+     * @memberof WorkspacesCreate400Response
+     */
+    'type': ProblemsProblemType;
+    /**
+     *
+     * @type {number}
+     * @memberof WorkspacesCreate400Response
+     */
+    'status'?: WorkspacesCreate400ResponseStatusEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesCreate400Response
+     */
+    'title': string;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesCreate400Response
+     */
+    'detail': string;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesCreate400Response
+     */
+    'instance'?: string;
+}
+
+export const WorkspacesCreate400ResponseStatusEnum = {
+    NUMBER_400: 400
+} as const;
+
+export type WorkspacesCreate400ResponseStatusEnum = typeof WorkspacesCreate400ResponseStatusEnum[keyof typeof WorkspacesCreate400ResponseStatusEnum];
+
+/**
+ *
+ * @export
  * @interface WorkspacesCreateWorkspaceRequest
  */
 export interface WorkspacesCreateWorkspaceRequest {
@@ -1129,6 +1268,50 @@ export interface WorkspacesCreateWorkspaceResponse {
     'modified': string;
 }
 
+
+/**
+ *
+ * @export
+ * @interface WorkspacesDelete400Response
+ */
+export interface WorkspacesDelete400Response {
+    /**
+     *
+     * @type {ProblemsProblemType}
+     * @memberof WorkspacesDelete400Response
+     */
+    'type': ProblemsProblemType;
+    /**
+     *
+     * @type {number}
+     * @memberof WorkspacesDelete400Response
+     */
+    'status'?: WorkspacesDelete400ResponseStatusEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesDelete400Response
+     */
+    'title': string;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesDelete400Response
+     */
+    'detail': string;
+    /**
+     *
+     * @type {string}
+     * @memberof WorkspacesDelete400Response
+     */
+    'instance'?: string;
+}
+
+export const WorkspacesDelete400ResponseStatusEnum = {
+    NUMBER_400: 400
+} as const;
+
+export type WorkspacesDelete400ResponseStatusEnum = typeof WorkspacesDelete400ResponseStatusEnum[keyof typeof WorkspacesDelete400ResponseStatusEnum];
 
 /**
  *
@@ -1409,50 +1592,6 @@ export interface WorkspacesReadWorkspaceWithAncestryResponse {
     'modified': string;
 }
 
-
-/**
- *
- * @export
- * @interface WorkspacesUpdate400Response
- */
-export interface WorkspacesUpdate400Response {
-    /**
-     *
-     * @type {ProblemsProblemType}
-     * @memberof WorkspacesUpdate400Response
-     */
-    'type'?: ProblemsProblemType;
-    /**
-     *
-     * @type {number}
-     * @memberof WorkspacesUpdate400Response
-     */
-    'status'?: WorkspacesUpdate400ResponseStatusEnum;
-    /**
-     *
-     * @type {string}
-     * @memberof WorkspacesUpdate400Response
-     */
-    'title'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof WorkspacesUpdate400Response
-     */
-    'detail'?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof WorkspacesUpdate400Response
-     */
-    'instance'?: string;
-}
-
-export const WorkspacesUpdate400ResponseStatusEnum = {
-    NUMBER_400: 400
-} as const;
-
-export type WorkspacesUpdate400ResponseStatusEnum = typeof WorkspacesUpdate400ResponseStatusEnum[keyof typeof WorkspacesUpdate400ResponseStatusEnum];
 
 /**
  *


### PR DESCRIPTION
## Summary

- Regenerates the RBAC v2 client from the latest OpenAPI spec
- Adds `withAncestry` parameter to `WorkspacesListParams` for tree navigation (RHCLOUD-49062)
- Updates type definitions and error types across v2 endpoints
- Fixes stale `package-lock.json` (prism-cli version mismatch with Node 24)

## Test plan

- [x] `nx run @redhat-cloud-services/rbac-client:generate` succeeds
- [x] `nx run @redhat-cloud-services/rbac-client:build` succeeds
- [x] `nx run @redhat-cloud-services/rbac-client:integration-v2` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)