### PR TITLE
chore(ci):  fix package release process and improve security

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -10,6 +10,9 @@ inputs:
   gh_email:
     description: 'Github email'
     required: true
+  gpg_private_key:
+    description: 'GPG private key for signing commits (passphrase-less)'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -17,11 +20,18 @@ runs:
     - name: Install deps
       shell: bash
       run: npm ci
+    - name: Import GPG key
+      shell: bash
+      run: |
+        echo "${{ inputs.gpg_private_key }}" | base64 -d | gpg --batch --import
+        gpg --list-secret-keys --keyid-format LONG
     - name: git config
       shell: bash
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
+        git config commit.gpgsign true
+        git config user.signingkey $(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
     - name: Release
       shell: bash
       env:
@@ -31,6 +41,9 @@ runs:
         # See: https://github.com/nrwl/nx/issues/22066#issuecomment-2576366862
         # See: https://github.com/nrwl/nx/blob/5ea2e47acfa9d175546daa922ce40905533f1074/packages/nx/src/utils/package-manager.ts#L207-L213
         npm_config_legacy_peer_deps: false
+        # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
+        # https://philna.sh/blog/2026/01/28/trusted-publishing-npm/
+        NPM_CONFIG_PROVENANCE: true
       run: npx nx release --yes
     - name: Push release commit and tags
       shell: bash
@@ -39,5 +52,8 @@ runs:
       # createRelease (GitHub/GitLab releases) is enabled. Since we use createReleaseInGitHub: false,
       # we push manually here so that the version bumps in package.json reach the remote and
       # nacho-bot can create PRs in consuming repos.
+      # HUSKY=0 disables pre-push hooks in CI — tests are run separately by the CI pipeline.
+      env:
+        HUSKY: '0'
       run: git push --follow-tags
 

--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -24,14 +24,13 @@ runs:
       shell: bash
       run: |
         echo "${{ inputs.gpg_private_key }}" | base64 -d | gpg --batch --import
-        gpg --list-secret-keys --keyid-format LONG
     - name: git config
       shell: bash
       run: |
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
-        git config user.signingkey $(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+        git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_name }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Release
       shell: bash
       env:

--- a/.github/actions/setup-environment/action.yaml
+++ b/.github/actions/setup-environment/action.yaml
@@ -26,7 +26,6 @@ runs:
     - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       with:
         node-version-file: '.nvmrc'
-        registry-url: 'https://registry.npmjs.org'
     - name: Show final versions
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,4 @@ jobs:
           gh_token: ${{ secrets.BOT_GH_TOKEN }}
           gh_name: ${{ secrets.GH_NAME }}
           gh_email: ${{ secrets.GH_EMAIL }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: Handle stale issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run daily at midnight UTC
+  workflow_dispatch: # Allow manual triggers
+
+jobs:
+  call-stale-workflow:
+    uses: RedHatInsights/shared-workflows/.github/workflows/stale.yml@master
+    # Optional: customize inputs
+    # with:
+    #   days-before-stale: 60
+    #   days-before-close: 5
+    #   exempt-issue-labels: "work-in-progress, in-progress, in-review, help-wanted, blocked, wip, depfu, dependabot, dependencies"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npm test

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,13 @@
 # All Konflux tekton configuration changes review from admins
 #.tekton/** @RedHatInsights/experience-services-admins
 
+# Protect Husky git hooks from unauthorized modification
+.husky/** @RedHatInsights/experience-services-admins
+
+# Protect package lifecycle scripts and npm configuration
+package.json @RedHatInsights/experience-services-admins
+.npmrc @RedHatInsights/experience-services-admins
+
 # Protect .npmignore - package publish contents control
 .npmignore @RedHatInsights/experience-services-admins
 

--- a/nx.json
+++ b/nx.json
@@ -63,6 +63,7 @@
     "version": {
       "preVersionCommand": "npx nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client",
       "conventionalCommits": true,
+      "fallbackCurrentVersionResolver": "disk",
       "preserveLocalDependencyProtocols": false,
       "versionActionsOptions": {
         "skipLockFileUpdate": false

--- a/nx.json
+++ b/nx.json
@@ -58,7 +58,7 @@
     "git": {
       "commit": true,
       "tag": true,
-      "commitMessage": "chore(release): publish\n\n{releaseNotes}"
+      "commitMessage": "chore(versions): package.json version sync + changelog [skip ci]\n\n{releaseNotes}"
     },
     "version": {
       "preVersionCommand": "npx nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client",


### PR DESCRIPTION
## Summary
  Applies CI/CD security and reliability improvements from frontend-components repo to javascript-clients.

  ## Changes
  
  ### Release Security
  - **GPG signing**: nacho-bot commits now signed with GPG key (prevents unsigned commit rejection)
  - **NPM provenance**: enabled `NPM_CONFIG_PROVENANCE=true` for package attestations
  - **OIDC auth**: removed `registry-url` from setup-node to fix OIDC authentication

  ### CI Reliability
  - **Skip retrigger**: release commits include `[skip ci]` to prevent infinite loops
  - **Disable hooks in CI**: `HUSKY=0` on git push during release (tests run separately)

  ### Supply Chain Protection
  - **CODEOWNERS**: require admin approval for `.husky/**`, `package.json`, `.npmrc` (prevents malicious hook/lifecycle script injection)
  - **Stale workflow**: auto-close inactive issues/PRs via shared-workflows

  ## References
  Based on frontend-components PRs:
  - #2368 (GPG signing)
  - #2359 (OIDC fix)
  - #2358 (provenance)
  - #2370 (skip ci)
  - #2371 (CODEOWNERS + hooks)
  - #2373 (stale workflow)
