### PR TITLE
chore(ci): select signing key by email

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -30,7 +30,7 @@ runs:
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
-        git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_name }}" | awk -F: '/^sec:/ {print $5; exit}')
+        git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Release
       shell: bash
       env:


### PR DESCRIPTION
Select nach-bot GPG key by email instead of user name due to formatting mismatch in name. Email won't appear in logs, because it comes from a Github secret. 