### PR TITLE
fix(release): move git config to subcommands

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -55,11 +55,6 @@
   "release": {
     "projects": ["packages/*"],
     "projectsRelationship": "independent",
-    "git": {
-      "commit": true,
-      "tag": true,
-      "commitMessage": "chore(versions): package.json version sync + changelog [skip ci]\n\n{releaseNotes}"
-    },
     "version": {
       "preVersionCommand": "npx nx run-many -t build --exclude=@redhat-cloud-services/CLIENTNAME-client",
       "conventionalCommits": true,
@@ -68,7 +63,12 @@
       "versionActionsOptions": {
         "skipLockFileUpdate": false
       },
-      "manifestRootsToUpdate": ["{projectRoot}", "{projectRoot}/dist"]
+      "manifestRootsToUpdate": ["{projectRoot}", "{projectRoot}/dist"],
+      "git": {
+        "commit": true,
+        "tag": true,
+        "commitMessage": "chore(versions): package.json version sync + changelog [skip ci]\n\n{releaseNotes}"
+      }
     },
     "conventionalCommits": {
       "useCommitScope": true
@@ -78,6 +78,9 @@
       "projectChangelogs": {
         "file": "{projectRoot}/CHANGELOG.md",
         "createReleaseInGitHub": false
+      },
+      "git": {
+        "commit": false
       }
     },
     "releaseTag": {


### PR DESCRIPTION
## Problem
  
  `nx release` failed because:
  1. June 1 supply chain attack burned version numbers 2.0.8–2.0.11 (shared), 2.1.8–2.1.11 (vulnerabilities), etc. across all packages
  2. `nx.json` had deprecated `release.git` config at top level instead of under subcommands

  ## Changes
  
  - Moved `release.git` → `release.version.git` + `release.changelog.git` in nx.json
  - Created skip-ahead tags (e.g., `shared-2.0.11`) pointing to last legitimate release commits
  - Pushed 15 tags to upstream to bypass burned version ranges
  
  ## Verification

  `npx nx release version --dry-run` now succeeds — all packages resolve from git tags, next versions skip past burned range (2.0.12, 2.1.12, 4.0.7, etc.).