### PR TITLE
ci: add pre-release version verification check

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -31,6 +31,9 @@ runs:
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
+    - name: Verify version alignment
+      shell: bash
+      run: ./.github/scripts/verify-versions.sh
     - name: Release
       shell: bash
       env:

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# verify-versions.sh
+#
+# Compares package versions across three sources (package.json, git tags, npm registry)
+# for all releasable packages in this monorepo. Intended to run before `nx release`
+# in CI to prevent releasing from an inconsistent state.
+#
+# Exit 0: all versions aligned
+# Exit 1: at least one mismatch detected
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+mismatch=0
+# Column widths for alignment
+printf "%-60s %-12s %-12s %-15s %s\n" "PACKAGE" "DISK" "GIT TAG" "NPM" "STATUS"
+printf '%.0s-' {1..110}
+printf '\n'
+
+for dir in "$REPO_ROOT"/packages/*/; do
+  dirname="$(basename "$dir")"
+
+  pkg_json="$dir/package.json"
+  if [[ ! -f "$pkg_json" ]]; then
+    continue
+  fi
+
+  # Read package name and version from package.json using node (always available in CI,
+  # avoids jq dependency and handles edge cases better than grep/sed)
+  pkg="$(node -p "require('$pkg_json').name")"
+  disk_ver="$(node -p "require('$pkg_json').version")"
+
+  # Skip private packages — they are not published to npm or tagged
+  private="$(node -p "require('$pkg_json').private || false")"
+  if [[ "$private" == "true" ]]; then
+    continue
+  fi
+
+  # --- Git tag version ---
+  # Tag pattern from nx.json: {projectName}-{version} where projectName = npm package name
+  # Use glob "${pkg}-*" then strip the prefix and filter for version-like results.
+  # This handles the ambiguity where e.g. "@redhat-cloud-services/compliance-client-*"
+  # also matches "@redhat-cloud-services/compliance-client-utilities-*" (if such a package existed).
+  # After stripping "${pkg}-", hypothetical utilities tags become "utilities-4.12.0" which does NOT
+  # start with a digit, so grep '^[0-9]' filters them out.
+  tag_ver="$(
+    git tag --list "${pkg}-*" \
+      | sed "s|^${pkg}-||" \
+      | grep '^[0-9]' \
+      | sort -V \
+      | tail -1
+  )" || true
+  [[ -z "$tag_ver" ]] && tag_ver="NONE"
+
+  # --- npm registry version ---
+  npm_ver="$(npm view "$pkg" version 2>/dev/null)" || true
+  [[ -z "$npm_ver" ]] && npm_ver="NOT_ON_NPM"
+
+  # --- Compare ---
+  if [[ "$disk_ver" == "$tag_ver" && "$disk_ver" == "$npm_ver" ]]; then
+    status="OK"
+    marker="✓"
+  elif [[ "$tag_ver" == "NONE" && "$npm_ver" == "NOT_ON_NPM" ]]; then
+    # New package: no tag, not published. Flag as informational but still a mismatch.
+    status="NEW_PACKAGE"
+    marker="!"
+    mismatch=1
+    echo "::error::${pkg}: new/unpublished package (disk=${disk_ver}, tag=NONE, npm=NOT_ON_NPM). Verify this is intentional."
+  else
+    status="MISMATCH"
+    marker="✗"
+    mismatch=1
+    echo "::error::${pkg}: version mismatch (disk=${disk_ver}, tag=${tag_ver}, npm=${npm_ver})"
+  fi
+
+  printf "%-60s %-12s %-12s %-15s %s %s\n" "$pkg" "$disk_ver" "$tag_ver" "$npm_ver" "$marker" "$status"
+done
+
+echo ""
+if [[ $mismatch -ne 0 ]]; then
+  echo "Version verification FAILED. Fix mismatches before releasing."
+  exit 1
+else
+  echo "All package versions are aligned across disk, git tags, and npm registry."
+  exit 0
+fi

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -54,7 +54,7 @@ for dir in "$REPO_ROOT"/packages/*/; do
   [[ -z "$tag_ver" ]] && tag_ver="NONE"
 
   # --- npm registry version ---
-  npm_ver="$(npm view "$pkg" version 2>/dev/null)" || true
+  npm_ver="$(npm view "$pkg" version --fetch-timeout=10000 2>/dev/null)" || true
   [[ -z "$npm_ver" ]] && npm_ver="NOT_ON_NPM"
 
   # --- Compare ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4
       - uses: './.github/actions/setup-environment'
       # cache cypress runner


### PR DESCRIPTION
### Description
  <!-- Summary of proposed changes: what and why. -->
The version verification script acts as a pre-release safety gate by ensuring `package.json` versions, git tags, and npm registry versions are aligned before `nx release` runs. It prevents silent corruption scenarios like: (1) incorrect tags being pushed that would cause version skipping on npm, (2) release commit push failures that leave the remote in an inconsistent state (packages published but tags/package.json not updated), and (3) malicious or accidental npm publishes without corresponding git tags. By failing fast with clear diagnostics when versions are misaligned, it catches state corruption before nx release compounds the problem, saving manual cleanup effort and preventing consumer-facing version gaps.

  [RHCLOUD-49173](https://issues.redhat.com/browse/RHCLOUD-49173)

  **Problem:** No validation before `nx release` runs. If package.json versions, git tags, or npm versions are out of sync, release process can fail mid-flight or publish incorrect versions.

  **Solution:** New `verify-versions.sh` script checks version alignment across three sources (package.json, git tags, npm registry) for all public packages. Runs in CI before release step. Fails fast with clear error messages if mismatches detected.

  **Changes:**
  - `.github/scripts/verify-versions.sh` — validation script (compares 18 packages across 3 sources)
  - `.github/actions/release/action.yaml` — add verification step before `nx release`

  ---

  ### How to test locally
  <!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
  <!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

  **Manual execution:**

  ```bash
  bash .github/scripts/verify-versions.sh
```

  Expected output (aligned state):

```bash
  PACKAGE                                                      DISK         GIT TAG      NPM             STATUS
  --------------------------------------------------------------------------------------------------------------
  @redhat-cloud-services/compliance-client                     4.0.7        4.0.7        4.0.7           ✓ OK
  @redhat-cloud-services/config-manager-client                 5.0.8        5.0.8        5.0.8           ✓ OK
```
  ...
  All package versions are aligned across disk, git tags, and npm registry.

  Expected output (mismatch):

```bash
  ::error::@redhat-cloud-services/rbac-client: version mismatch (disk=9.0.8, tag=9.0.7, npm=9.0.7)
```

  ...
  Version verification FAILED. Fix mismatches before releasing.

  Exit code: 0 = aligned, 1 = mismatch.

  Test mismatch detection:
  1. Bump a package version: cd packages/rbac && npm version patch --no-git-tag-version
  2. Run script: bash .github/scripts/verify-versions.sh
  3. Should fail with mismatch error
  4. Revert: git restore packages/rbac/package.json

  ---
  Anything reviewers should know?

  <!-- Trade-offs, performance considerations, pre/post merge actions required. -->

  - Script skips build-utils (private package, not published)
  - Checks all 17 public packages (compliance, config-manager, entitlements, host-inventory, insights, integrations, notifications, patch, quickstarts, rbac, remediations, rhsm-subscriptions-utilization, scheduler, javascript-clients-shared, sources, topological-inventory, vulnerabilities)
  - Uses node -p for JSON parsing (no jq dependency)
  - New packages (tag=NONE, npm=NOT_ON_NPM) flagged as error — reviewer must confirm intentional
  - Runs before nx release in CI — blocks release on mismatch

  ---
  Checklist

  - [ ] Tests: new/updated tests cover the change (N/A — bash script, manually verified)
  - [ ] API: spec updated if endpoints changed (N/A)
  - [ ] Migrations: backwards compatible if schema changed (N/A)
  - [ ] Dependencies: no known impact to dependent services (N/A)
  - [ ] Security: reviewed against secure coding checklist (N/A — CI validation script)

  AI disclosure

  <!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->

  Assisted by: Claude Code

[RHCLOUD-49173]: https://redhat.atlassian.net/browse/RHCLOUD-49173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ