### PR TITLE
chore(ci): use git tag --merged in verify-versions.sh to match nx release tag resolution

### DIFF
--- a/.github/actions/release/action.yaml
+++ b/.github/actions/release/action.yaml
@@ -30,6 +30,7 @@ runs:
         git config user.name "${{ inputs.gh_name }}"
         git config user.email "${{ inputs.gh_email }}"
         git config commit.gpgsign true
+        git config tag.gpgsign true
         git config user.signingkey $(gpg --list-secret-keys --with-colons "${{ inputs.gh_email }}" | awk -F: '/^sec:/ {print $5; exit}')
     - name: Verify version alignment
       shell: bash

--- a/.github/scripts/verify-versions.sh
+++ b/.github/scripts/verify-versions.sh
@@ -45,7 +45,7 @@ for dir in "$REPO_ROOT"/packages/*/; do
   # After stripping "${pkg}-", hypothetical utilities tags become "utilities-4.12.0" which does NOT
   # start with a digit, so grep '^[0-9]' filters them out.
   tag_ver="$(
-    git tag --list "${pkg}-*" \
+    git tag --merged HEAD --list "${pkg}-*" \
       | sed "s|^${pkg}-||" \
       | grep '^[0-9]' \
       | sort -V \


### PR DESCRIPTION
### Description
  
  Changed verify-versions.sh to use `git tag --merged HEAD` instead of `git tag --list` to match nx release's tag resolution behavior. Previously, the script saw all tags  (including orphaned ones from failed release pushes), while nx only considers tags reachable from HEAD, causing the script to pass validation when nx would fail.

This prevents false-positive validations where versions appear aligned but nx cannot see the tags during release.

Also added git config to sign tags, which are currently showing as unverified tags. 

### AI disclosure
Assisted by: Claude Code