### PR TITLE
docs: semver requires full package names in commit scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,14 +54,25 @@ Husky is configured:
 
 **CRITICAL: Do not change `useCommitScope` in `nx.json`**
 
-`nx.json` has `"conventionalCommits": { "useCommitScope": true }` (line 73). This controls how breaking changes affect version bumps:
+`nx.json` has `"conventionalCommits": { "useCommitScope": true }` (line 73). This requires commit scopes to **exactly match** the full Nx project name for version bumps:
 
-- `useCommitScope: true` (current, REQUIRED) — Breaking changes only bump packages named in commit scope. Example: `feat(rbac)!: breaking change` bumps rbac to major, other packages get patch for dependency update.
-- `useCommitScope: false` (DANGEROUS) — Breaking changes bump ALL packages with modified files to major, regardless of commit scope. Causes `preserveMatchingDependencyRanges` failures when shared package jumps major but clients depend on `^2.x`.
+- `useCommitScope: true` (current, REQUIRED) — Scope must match full project name (e.g., `@redhat-cloud-services/rbac-client`). Standard conventional commits rules apply: `fix` → patch, `feat` → minor, `!` → major. Non-matching scopes (e.g., `feat(rbac)!:`) are treated as indirect changes and capped at patch.
+- `useCommitScope: false` — Ignores scope, uses Nx affected graph. Risk: breaking change touching `packages/shared/` → major bumps all 15 client packages, breaking `preserveMatchingDependencyRanges`.
 
-**Why this matters:** Shared package is a dependency of all clients. With `useCommitScope: false`, any breaking change touching shared's files triggers major bumps across all 15 packages, breaking semver ranges and failing releases.
+**Commit scope convention:** Always use full project name as scope:
+```
+feat(@redhat-cloud-services/scheduler-client)!: remove v1 endpoints
+```
 
-See: Nx source `packages/nx/src/command-line/release/utils/semver.ts:44`
+Multiple packages (comma-separated, **no spaces**):
+```
+feat(@redhat-cloud-services/rbac-client,@redhat-cloud-services/scheduler-client)!: breaking change
+```
+
+Not: `feat(scheduler)!:` (scope mismatch, capped at patch)
+Not: `feat(rbac, scheduler)!:` (spaces break match)
+
+See: Nx source `node_modules/nx/src/command-line/release/utils/semver.js` (determineSemverChange)
 
 ## Package Publishing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,15 +80,19 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/). Com
 type(scope): description
 
 # Examples:
-feat(rbac): add v2 endpoint support
-fix(build-utils): handle missing spec file gracefully
+feat(@redhat-cloud-services/rbac-client): add v2 endpoint support
+fix(@redhat-cloud-services/build-utils): handle missing spec file gracefully
+feat(@redhat-cloud-services/scheduler-client)!: remove v1 endpoints
+feat(@redhat-cloud-services/rbac-client,@redhat-cloud-services/scheduler-client)!: breaking change
 chore(deps): update axios to 1.13.5
 docs(readme): add troubleshooting section
 ```
 
 **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
 
-**Scope**: Package name (e.g., `rbac`, `build-utils`, `shared`) or area (`deps`, `ci`, `readme`).
+**Scope**: Full Nx project name for packages (e.g., `@redhat-cloud-services/rbac-client`, `@redhat-cloud-services/shared`) or area (`deps`, `ci`, `readme`). Multiple packages: comma-separated with **no spaces** (e.g., `pkg1,pkg2`).
+
+**Version bumps**: `fix` → patch, `feat` → minor, `!` → major (standard conventional commits).
 
 ## Testing
 
@@ -115,14 +119,17 @@ Releases are automated via Nx Release on the `main` branch. Each package is inde
 
 **Do not change `"useCommitScope": true` in `nx.json` (line 73).**
 
-This setting controls how breaking changes affect version bumps:
+This setting requires commit scopes to **exactly match** the full Nx project name for version bumps to apply correctly:
 
-- **`true` (current)**: Breaking changes only bump packages named in commit scope
-  - Example: `feat(rbac)!: breaking change` → rbac gets major bump, other packages get patch for dependency update
-  - Prevents cascading major bumps across unrelated packages
+- **`true` (current)**: Scope must match full project name (e.g., `@redhat-cloud-services/rbac-client`)
+  - `feat(@redhat-cloud-services/rbac-client)!:` → rbac gets major bump
+  - `feat(rbac)!:` → rbac gets only patch (scope mismatch, treated as indirect change)
+  - Standard conventional commits rules: `fix` → patch, `feat` → minor, `!` → major
 
-- **`false` (dangerous)**: Breaking changes bump ALL packages with modified files to major
-  - Causes `preserveMatchingDependencyRanges` failures when shared package jumps major but clients still depend on `^2.x`
-  - Results in failed releases
+- **`false`**: Ignores scope, applies commit type's semver bump to ALL packages in Nx affected graph
+  - `feat(shared):` touching `packages/shared/` → **minor bump** for all 15 client packages (affected by dependency)
+  - `feat(shared)!:` → **major bump** for all 15 clients
+  - Breaking change risk: cascading major bumps break `preserveMatchingDependencyRanges` semver constraints
+  - Commit type determines bump (`feat` → minor, `fix` → patch, `!` → major), applied uniformly to all affected
 
-Since `packages/shared/` is a dependency of all 15 client packages, setting `useCommitScope: false` would cause any breaking change touching shared files to trigger major bumps across the entire monorepo.
+**Always use the full project name as scope** for package changes.


### PR DESCRIPTION
Summary

  Documents Nx Release's useCommitScope: true behavior to prevent version bump failures from scope mismatches. Recent commit feat(scheduler)!: only triggered patch bump instead of major because scope scheduler didn't match project name @redhat-cloud-services/scheduler-client.

  Changes

  Updated CLAUDE.md and CONTRIBUTING.md with:

  Commit scope requirements:
  - Must use full Nx project name: feat(@redhat-cloud-services/rbac-client): ...
  - Multiple packages: comma-separated, no spaces: feat(pkg1,pkg2)!: ...

  Version bump rules:
  - fix → patch, feat → minor, ! → major
  - Scope must exactly match project name
  - Non-matching scopes (e.g., feat(rbac)!:) treated as indirect changes → capped at patch

  useCommitScope behavior:
  - true (current): exact scope match required, follows conventional commits semver
  - false: ignores scope, applies bump to ALL affected packages (risky with shared dependencies)

  Technical Details

  Nx performs exact string comparison (commit.scope === projectName):
  - Matching scope: feat(@redhat-cloud-services/scheduler-client)!: → major
  - Non-matching scope: feat(scheduler)!: → patch (indirect change)
  - Spaces break multi-package match: feat(pkg1, pkg2)!: → invalid

  Source: node_modules/nx/src/command-line/release/utils/semver.js (determineSemverChange)

  Files Modified

  - CLAUDE.md — Nx Release Configuration section
  - CONTRIBUTING.md — Commit Guidelines and Releases sections

  Resolves: RHCLOUD-49360
