### PR TITLE
ci(commitlint): enforce full Nx project names for feat/fix/breaking c…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Husky is configured:
 
 `nx.json` has `"conventionalCommits": { "useCommitScope": true }` (line 73). This controls how breaking changes affect version bumps:
 
-- `useCommitScope: true` (current, REQUIRED) — Breaking changes only bump packages named in commit scope. Example: `feat(rbac)!: breaking change` bumps rbac to major, other packages get patch for dependency update.
+- `useCommitScope: true` (current, REQUIRED) — Breaking changes only bump packages named in commit scope. Example: `feat(@redhat-cloud-services/rbac-client)!: breaking change` bumps rbac-client to major, other packages get patch for dependency update.
 - `useCommitScope: false` (DANGEROUS) — Breaking changes bump ALL packages with modified files to major, regardless of commit scope. Causes `preserveMatchingDependencyRanges` failures when shared package jumps major but clients depend on `^2.x`.
 
 **Why this matters:** Shared package is a dependency of all clients. With `useCommitScope: false`, any breaking change touching shared's files triggers major bumps across all 15 packages, breaking semver ranges and failing releases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,16 +79,27 @@ This repo uses [Conventional Commits](https://www.conventionalcommits.org/). Com
 ```
 type(scope): description
 
-# Examples:
-feat(rbac): add v2 endpoint support
-fix(build-utils): handle missing spec file gracefully
+# Examples (versioning types — feat, fix, breaking):
+feat(@redhat-cloud-services/rbac-client): add v2 endpoint support
+fix(@redhat-cloud-services/build-utils): handle missing spec file gracefully
+feat(@redhat-cloud-services/javascript-clients-shared): add retry interceptor
+
+# Examples (non-versioning types — chore, docs, ci, etc.):
 chore(deps): update axios to 1.13.5
 docs(readme): add troubleshooting section
+ci(github): update workflow
 ```
 
 **Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `ci`, `build`, `revert`
 
-**Scope**: Package name (e.g., `rbac`, `build-utils`, `shared`) or area (`deps`, `ci`, `readme`).
+**Scope rules**:
+- **`feat`, `fix`, or breaking changes** (`!` marker or `BREAKING CHANGE` footer): Must use full Nx project name
+  - Valid: `feat(@redhat-cloud-services/rbac-client): ...`
+  - Invalid: `feat(rbac): ...` or `feat(deps): ...`
+- **Non-versioning types** (`chore`, `docs`, `ci`, etc.): Can use short names or area scopes (`deps`, `ci`, `readme`)
+  - Valid: `chore(deps): ...` or `docs(readme): ...`
+
+**Why full names for versioning commits?** Nx uses commit scope to determine which package gets bumped. Short scopes or area scopes cause Nx to silently cap version bumps at patch, even when `feat` or breaking change promises minor/major.
 
 ## Testing
 
@@ -118,7 +129,7 @@ Releases are automated via Nx Release on the `main` branch. Each package is inde
 This setting controls how breaking changes affect version bumps:
 
 - **`true` (current)**: Breaking changes only bump packages named in commit scope
-  - Example: `feat(rbac)!: breaking change` → rbac gets major bump, other packages get patch for dependency update
+  - Example: `feat(@redhat-cloud-services/rbac-client)!: breaking change` → rbac-client gets major bump, other packages get patch for dependency update
   - Prevents cascading major bumps across unrelated packages
 
 - **`false` (dangerous)**: Breaking changes bump ALL packages with modified files to major

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,7 +16,6 @@ function getNxProjects() {
 }
 
 const validProjects = getNxProjects();
-const AREA_SCOPES = ['deps', 'ci', 'readme', 'docs'];
 
 module.exports = {
   extends: ['@commitlint/config-conventional'],
@@ -67,7 +66,6 @@ module.exports = {
           const scopes = scope.split(',');
 
           for (const s of scopes) {
-            if (AREA_SCOPES.includes(s)) continue;
             if (!projectSet.has(s)) {
               const commitType = isBreaking
                 ? 'breaking (!)/feat/fix'

--- a/commitlint.config.test.js
+++ b/commitlint.config.test.js
@@ -58,13 +58,13 @@ describe('commitlint scope-full-name-for-versioning', () => {
       expect(result.valid).toBe(true);
     });
 
-    it('feat with area scope (deps)', async () => {
-      const result = await lintMessage('feat(deps): add new dep');
+    it('chore with area scope (deps)', async () => {
+      const result = await lintMessage('chore(deps): add new dep');
       expect(result.valid).toBe(true);
     });
 
-    it('feat with area scope (ci)', async () => {
-      const result = await lintMessage('feat(ci): update workflow');
+    it('chore with area scope (ci)', async () => {
+      const result = await lintMessage('chore(ci): update workflow');
       expect(result.valid).toBe(true);
     });
 
@@ -149,10 +149,40 @@ describe('commitlint scope-full-name-for-versioning', () => {
       expect(result.errors[0].message).toContain('Scope required');
     });
 
+    it('fix with no scope', async () => {
+      const result = await lintMessage('fix: global change');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain('Scope required');
+    });
+
     it('breaking with no scope', async () => {
       const result = await lintMessage('fix!: breaking fix');
       expect(result.valid).toBe(false);
       expect(result.errors[0].message).toContain('Scope required');
+    });
+
+    it('feat with area scope (deps)', async () => {
+      const result = await lintMessage('feat(deps): add new dep');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain(
+        'must be a full Nx project name'
+      );
+    });
+
+    it('feat with area scope (ci)', async () => {
+      const result = await lintMessage('feat(ci): update workflow');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain(
+        'must be a full Nx project name'
+      );
+    });
+
+    it('fix with area scope (docs)', async () => {
+      const result = await lintMessage('fix(docs): update readme');
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].message).toContain(
+        'must be a full Nx project name'
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

  [RHCLOUD-49361](https://redhat.atlassian.net/browse/RHCLOUD-49361)

  **Problem:** Commitlint allowed area scopes (`deps`, `ci`, etc.) on `feat`/`fix` commits. Nx ignores scopes that don't match project names → silently caps bumps at patch even when commit type promises minor/major.

  **Fix:** Remove `AREA_SCOPES` bypass from commitlint config. Now `feat`/`fix`/breaking require full Nx project name (`@redhat-cloud-services/rbac-client`). Area scopes only valid on non-versioning types (`chore`, `docs`, `ci`).

  **Files changed:**
  - `commitlint.config.js` — removed AREA_SCOPES allowlist
  - `commitlint.config.test.js` — moved area scope tests to invalid for feat/fix, valid for chore
  - `CONTRIBUTING.md` — updated commit examples + scope rules with rationale
  - `CLAUDE.md` — fixed breaking change example

  Matches strict enforcement from frontend-components repo.

  ---

  ### How to test locally

  ```bash
  # Should fail (area scope on feat):
  echo "feat(deps): upgrade PatternFly" | npx commitlint

  # Should pass (full project name):
  echo "feat(@redhat-cloud-services/rbac-client): add feature" | npx commitlint

  # Should pass (area scope on chore):
  echo "chore(deps): upgrade PatternFly" | npx commitlint

  # Run test suite:
  npx jest --config=commitlint.jest.config.js
```

  ---
  Anything reviewers should know?

  Breaking change for developer workflow. Previously valid commits like feat(deps): ... now rejected. Must use:
  - feat(@redhat-cloud-services/rbac-client): ... for versioning commits
  - chore(deps): ... for non-versioning commits

  Prevents silent version bump downgrades where developer expects minor bump but Nx delivers patch.

  ---
  Checklist

  - [x] Tests: new/updated tests cover the change
  - [x] API: spec updated if endpoints changed (or N/A) — N/A
  - [x] Migrations: backwards compatible if schema changed (or N/A) — N/A
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against secure coding checklist (or N/A) — N/A

  AI disclosure

  Assisted by: Claude Code

[RHCLOUD-49361]: https://redhat.atlassian.net/browse/RHCLOUD-49361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ