### PR TITLE
ci(release): add queue max to prevent dropped releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-release
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: write  # Needed for git push
       id-token: write  # Needed for npm publish


### PR DESCRIPTION
Based on CodeRabbit feedback:

> cancel-in-progress: false keeps the active release job, but pending runs still default to a single slot and newer releases can replace earlier ones. Add queue: max here so release jobs stay queued in FIFO order.