### PR TITLE
chore: update dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "fix(deps):"
+      prefix-development: "chore(deps-dev):"


### PR DESCRIPTION
Custom `dependabot.yaml` config file to ensure production packages trigger patch version bump, whereas dev depenencies do not. Also grouping minor and patch updates into a single PR. 